### PR TITLE
Copy permission bits from template to target #3

### DIFF
--- a/astrality/compiler.py
+++ b/astrality/compiler.py
@@ -167,3 +167,7 @@ def compile_template(
             )
 
         target.chmod(mode)
+    else:
+        # Copy template's file permissions to compiled target file
+        default_permissions = template.stat().st_mode & 0o777
+        target.chmod(default_permissions)

--- a/astrality/compiler.py
+++ b/astrality/compiler.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import stat
 from functools import partial
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
@@ -154,6 +155,10 @@ def compile_template(
     with open(target, 'w') as target_file:
         target_file.write(result)
 
+    # Copy template's file permissions to compiled target file
+    template_permissions = stat.S_IMODE(template.stat().st_mode)
+    target.chmod(template_permissions)
+
     if permissions:
         mode: int
         if isinstance(permissions, int):
@@ -167,7 +172,3 @@ def compile_template(
             )
 
         target.chmod(mode)
-    else:
-        # Copy template's file permissions to compiled target file
-        default_permissions = template.stat().st_mode & 0o777
-        target.chmod(default_permissions)

--- a/astrality/tests/test_compiler.py
+++ b/astrality/tests/test_compiler.py
@@ -159,6 +159,21 @@ def test_handling_of_undefined_context(tmpdir, caplog):
 
     assert "'this' is undefined" in caplog.record_tuples[0][2]
 
+def test_writing_template_file_with_default_permissions(tmpdir):
+    tmpdir = Path(tmpdir)
+    template = tmpdir / 'template'
+    template.write_text('content')
+    permission = 0o751
+    template.chmod(permission)
+    target = tmpdir / 'target'
+
+    compile_template(
+        template=template,
+        target=target,
+        context={},
+        shell_command_working_directory=tmpdir
+    )
+    assert (target.stat().st_mode & 0o777) == permission
 
 def test_writing_template_file_with_specific_permissions(tmpdir):
     tmpdir = Path(tmpdir)

--- a/astrality/tests/test_compiler.py
+++ b/astrality/tests/test_compiler.py
@@ -171,7 +171,7 @@ def test_writing_template_file_with_default_permissions(tmpdir):
         template=template,
         target=target,
         context={},
-        shell_command_working_directory=tmpdir
+        shell_command_working_directory=tmpdir,
     )
     assert (target.stat().st_mode & 0o777) == permission
 


### PR DESCRIPTION
Added functionality for copying a template's permission bits over to the generated target file in case the `permissions` option is not explicitly specified in the respective module.

Also added a test for the new functionality

Have not added the documentation for the changes to the docs yet. I can add it if needed