### PR TITLE
Expand environment variables

### DIFF
--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -20,7 +20,7 @@ which could be imported and accessed independently from other modules.
 import abc
 from collections import defaultdict
 import logging
-from os.path import relpath
+import os
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import (
@@ -110,8 +110,9 @@ class Action(abc.ABC):
             return self._absolute_path(of=substituted_string_path)
         elif isinstance(option_value, str):
             # The option is a string, and any placeholders should be
-            # substituted before it is returned.
-            return self.replace(option_value)
+            # substituted before it is returned. We also expand any environment
+            # variables that might be present.
+            return os.path.expandvars(self.replace(option_value))
         else:
             return option_value
 
@@ -236,7 +237,7 @@ class CompileAction(Action):
                 if path.is_file()
             )
             targets = tuple(
-                target / relpath(template_file, start=template_source)
+                target / os.path.relpath(template_file, start=template_source)
                 for template_file
                 in templates
             )

--- a/astrality/config.py
+++ b/astrality/config.py
@@ -271,7 +271,10 @@ def expand_path(path: Path, config_directory: Path) -> Path:
         path = config_directory / path
 
     # Return path where symlinks such as '..' are resolved
-    return path.resolve()
+    path = path.resolve()
+
+    # Expand environment variables and return as a Path object
+    return Path(os.path.expandvars(str(path)))
 
 
 def expand_globbed_path(path: Path, config_directory: Path) -> Set[Path]:

--- a/astrality/tests/actions/test_run_action.py
+++ b/astrality/tests/actions/test_run_action.py
@@ -124,7 +124,7 @@ def test_running_shell_command_with_environment_variable(caplog):
         (
             'astrality.actions',
             logging.INFO,
-            'Running command "echo $USER".',
+            f'Running command "echo {os.environ["USER"]}".',
         ),
         (
             'astrality',
@@ -132,3 +132,14 @@ def test_running_shell_command_with_environment_variable(caplog):
             os.environ['USER'] + '\n',
         )
     ]
+
+def test_that_environment_variables_are_expanded():
+    """String parameters in any Action type should expand env variables."""
+    run_action = RunAction(
+        options={'shell': 'echo $EXAMPLE_ENV_VARIABLE'},
+        directory=Path('/'),
+        replacer=lambda x: x,
+        context_store={},
+    )
+    command, _ = run_action.execute()
+    assert command == 'echo test_value'

--- a/astrality/tests/config/test_config.py
+++ b/astrality/tests/config/test_config.py
@@ -10,8 +10,6 @@ from astrality.config import (
     create_config_directory,
     dict_from_config_file,
     user_configuration,
-    expand_path,
-    expand_globbed_path,
     insert_into,
     resolve_config_directory,
 )
@@ -154,46 +152,6 @@ class TestCreateConfigDirectory:
         assert 'astrality.yml' in dir_contents
         assert 'modules' in dir_contents
         rmtree(created_config_dir)
-
-def test_expand_path_method(test_config_directory):
-    absolute_path = Path('/tmp/ast')
-    tilde_path = Path('~/dir')
-    relative_path = Path('test')
-
-    assert expand_path(
-        path=absolute_path,
-        config_directory=Path('/what/ever'),
-    ) == absolute_path
-
-    assert expand_path(
-        path=tilde_path,
-        config_directory=Path('/what/ever'),
-    ) == Path.home() / 'dir'
-
-    assert expand_path(
-        path=relative_path,
-        config_directory=test_config_directory,
-    ) == test_config_directory / 'test'
-
-def test_expand_globbed_path(test_config_directory):
-    """Globbed paths should allow one level of globbing."""
-    templates = Path('test_modules', 'using_all_actions')
-    paths = expand_globbed_path(
-        path=templates / '*',
-        config_directory=test_config_directory,
-    )
-    assert len(paths) == 5
-    assert test_config_directory / templates / 'module.template' in paths
-
-def test_expand_recursive_globbed_path(test_config_directory):
-    """Globbed paths should allow recursive globbing."""
-    templates = Path('test_modules', 'using_all_actions')
-    paths = expand_globbed_path(
-        path=templates / '**' / '*',
-        config_directory=test_config_directory,
-    )
-    assert len(paths) == 6
-    assert test_config_directory / templates / 'recursive' / 'empty.template' in paths
 
 @pytest.yield_fixture
 def dir_with_compilable_files(tmpdir):

--- a/astrality/tests/config/test_expand_path.py
+++ b/astrality/tests/config/test_expand_path.py
@@ -1,0 +1,47 @@
+"""Tests for astrality.config.expand_path."""
+
+from pathlib import Path
+
+from astrality.config import expand_globbed_path, expand_path
+
+
+def test_expand_path_method(test_config_directory):
+    absolute_path = Path('/tmp/ast')
+    tilde_path = Path('~/dir')
+    relative_path = Path('test')
+
+    assert expand_path(
+        path=absolute_path,
+        config_directory=Path('/what/ever'),
+    ) == absolute_path
+
+    assert expand_path(
+        path=tilde_path,
+        config_directory=Path('/what/ever'),
+    ) == Path.home() / 'dir'
+
+    assert expand_path(
+        path=relative_path,
+        config_directory=test_config_directory,
+    ) == test_config_directory / 'test'
+
+def test_expand_globbed_path(test_config_directory):
+    """Globbed paths should allow one level of globbing."""
+    templates = Path('test_modules', 'using_all_actions')
+    paths = expand_globbed_path(
+        path=templates / '*',
+        config_directory=test_config_directory,
+    )
+    assert len(paths) == 5
+    assert test_config_directory / templates / 'module.template' in paths
+
+def test_expand_recursive_globbed_path(test_config_directory):
+    """Globbed paths should allow recursive globbing."""
+    templates = Path('test_modules', 'using_all_actions')
+    paths = expand_globbed_path(
+        path=templates / '**' / '*',
+        config_directory=test_config_directory,
+    )
+    assert len(paths) == 6
+    assert test_config_directory / templates / 'recursive' / 'empty.template' in paths
+

--- a/astrality/tests/config/test_expand_path.py
+++ b/astrality/tests/config/test_expand_path.py
@@ -25,6 +25,17 @@ def test_expand_path_method(test_config_directory):
         config_directory=test_config_directory,
     ) == test_config_directory / 'test'
 
+def test_expansion_of_environment_variables(test_config_directory):
+    """
+    Environment variables should be expanded in paths.
+
+    See pytest.ini for available environment variables.
+    """
+    assert expand_path(
+        path=Path('${EXAMPLE_ENV_VARIABLE}/recursive'),
+        config_directory=test_config_directory / '$EXAMPLE_ENV_VARIABLE',
+    ) == test_config_directory / 'test_value' / 'test_value' / 'recursive'
+
 def test_expand_globbed_path(test_config_directory):
     """Globbed paths should allow one level of globbing."""
     templates = Path('test_modules', 'using_all_actions')

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -318,7 +318,7 @@ Here is an example:
         on_startup:
             compile:
                 - source: modules/scripts/executable.sh.template
-                  target: {{ env.XDG_CONFIG_HOME }}/bin/executable.sh
+                  target: ${XDG_CONFIG_HOME}/bin/executable.sh
                   permissions: 0o555
                 - source: modules/desktop/conky_module.template
 


### PR DESCRIPTION
Before this change, you had to specify ``{{ env.EXAMPLE }}`` whenever you wanted to use an environment variable.

This PR adds the capability to add environment variables in the UNIX way (``$EXAMPLE`` or ``${EXAMPLE}``) within any specified path and any specified string action parameter. Most users will end up trying this at some point, so we should support it.

You would still need to use the Jinja2 syntax whenever you want to use environment variables in YAML keys, but that should be really uncommon.