### PR TITLE
Add template filter functionality

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ Added
 - You can now compile all templates recursively within a directory. Just set
   ``source`` to a directory path. ``target`` must be a directory as well, and
   the relative file hierarchy is preserved.
+- You can now specify which filenames are considered templates when compiling
+  directories recursively.
+- Template target filenames can now be renamed by specifying a regular
+  expression capture group.
+- Non-template files can now be either symlinked, copied, or ignored.
 - The run action now supports ``timeout`` option, in order to set
   ``run_timeout`` on command-by-command basis.
 - ``compile`` actions now support an optional ``permissions`` field for

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -83,8 +83,11 @@ Changed
 - The ``trigger`` action now follows recursive ``trigger`` actions. Beware of
   circular trigger chains!
 
+- ``recompile_modified_templates`` has been renamed to
+  ``reprocess_modified_files``, as this option now also includes copied files.
+
 - Astrality will now only recompile templates that have already been compiled
-  when ``recompile_modified_templates`` is set to ``true``.
+  when ``reprocess_modified_files`` is set to ``true``.
 
 - The ``template`` compile action keyword has now been replaced with
   ``source``. This keyword makes more sense when we add support for compiling

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,13 @@ Versioning <http://semver.org/spec/v2.0.0.html>`_.
 Added
 -----
 
+- New ``symlink`` action type.
+- New ``copy`` action type.
+- New ``stow`` action type. This action allows you to either compile+symlink
+  or compile+copy, bisecting a directory based on filename regular expression
+  matching.
 - You can now compile all templates recursively within a directory. Just set
-  ``source`` to a directory path. ``target`` must be a directory as well, and
+  ``content`` to a directory path. ``target`` must be a directory as well, and
   the relative file hierarchy is preserved.
 - You can now specify which filenames are considered templates when compiling
   directories recursively.
@@ -90,8 +95,9 @@ Changed
   when ``reprocess_modified_files`` is set to ``true``.
 
 - The ``template`` compile action keyword has now been replaced with
-  ``source``. This keyword makes more sense when we add support for compiling
-  all templates within a directory.
+  ``content``. This keyword makes more sense when we add support for compiling
+  all templates within a directory. It also stays consistent with the new action
+  types that have been added.
 
   *Old syntax*
 
@@ -105,7 +111,7 @@ Changed
   .. code-block:: yaml
 
       compile:
-          - source: path/to/template
+          - content: path/to/template
 
 - The module list items within the module ``requires`` option is now
   a dictionary, where shell commands are specified under the ``shell`` keyword.

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -475,10 +475,7 @@ class StowAction(Action):
         )
 
         # Determine what to do with non-templates
-        non_templates_action = self.option(
-            key='non_templates',
-            default='symlink',
-        )
+        non_templates_action = self._options.get('non_templates', 'symlink')
         self.ignore_non_templates = non_templates_action.lower() == 'ignore'
 
         if non_templates_action.lower() not in ('copy', 'symlink', 'ignore',):

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -189,6 +189,7 @@ class CompileDict(RequiredCompileDict, total=False):
     """Allowable fields of compile action."""
 
     target: str
+    include: str
     permissions: str
 
 

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -182,7 +182,7 @@ class ImportContextAction(Action):
 class RequiredCompileDict(TypedDict):
     """Required fields of compile action."""
 
-    source: str
+    content: str
 
 
 class CompileDict(RequiredCompileDict, total=False):
@@ -216,12 +216,12 @@ class CompileAction(Action):
         elif 'target' not in self._options:
             # If no target is specified, then we can create a temporary file
             # and insert it into the configuration options.
-            template = self.option(key='source', path=True)
+            template = self.option(key='content', path=True)
             target = self._create_temp_file(template.name)
             self._options['target'] = str(target)  # type: ignore
 
         # These might either be file paths or directory paths
-        template_source = self.option(key='source', path=True)
+        template_source = self.option(key='content', path=True)
         target_source = self.option(key='target', path=True)
 
         if template_source.is_file():
@@ -420,7 +420,7 @@ class CompileAction(Action):
         """Return True if run action is responsible for template."""
         assert other.is_absolute()
 
-        if not self.option(key='source', path=True) == other:
+        if not self.option(key='content', path=True) == other:
             # This is not a managed template, so we will not recompile
             return False
 

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -246,7 +246,7 @@ class CompileAction(Action):
             logger = logging.getLogger(__name__)
             logger.error(
                 f'Could not compile template "{template_source}" '
-                f'to target "{target}". No such path!',
+                f'to target "{target_source}". No such path!',
             )
             return {}
 

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -346,6 +346,9 @@ class SymlinkAction(Action):
             include=include,
         )
         for content, symlink in links.items():
+            if symlink.is_file():
+                symlink.rename(symlink.parent / (str(symlink.name) + '.bak'))
+
             symlink.parent.mkdir(parents=True, exist_ok=True)
             symlink.symlink_to(content)
             self.symlinked_files[content].add(symlink)
@@ -714,6 +717,7 @@ class ActionBlock:
     """
 
     _import_context_actions: List[ImportContextAction]
+    _symlink_actions: List[SymlinkAction]
     _compile_actions: List[CompileAction]
     _run_actions: List[RunAction]
     _trigger_actions: List[TriggerAction]
@@ -736,6 +740,7 @@ class ActionBlock:
 
         for identifier, action_type in (
             ('import_context', ImportContextAction),
+            ('symlink', SymlinkAction),
             ('compile', CompileAction),
             ('run', RunAction),
             ('trigger', TriggerAction),
@@ -761,8 +766,13 @@ class ActionBlock:
         for import_context_action in self._import_context_actions:
             import_context_action.execute()
 
+    def symlink(self) -> None:
+        """Symlink files."""
+        for symlink_action in self._symlink_actions:
+            symlink_action.execute()
+
     def compile(self) -> None:
-        """Compile all templates."""
+        """Compile templates."""
         for compile_action in self._compile_actions:
             compile_action.execute()
 

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -459,6 +459,9 @@ class SymlinkAction(Action):
 
         :return: Dictionary with content keys and symlink values.
         """
+        if self.null_object:
+            return {}
+
         content = self.option(key='content', path=True)
         target = self.option(key='target', path=True)
         include = self.option(key='include', default=r'(.+)')
@@ -499,6 +502,9 @@ class CopyAction(Action):
 
         :return: Dictionary with content keys and copy values.
         """
+        if self.null_object:
+            return {}
+
         content = self.option(key='content', path=True)
         target = self.option(key='target', path=True)
         include = self.option(key='include', default=r'(.+)')

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -716,10 +716,11 @@ class ActionBlock:
     :param context_store: A reference to the global context store.
     """
 
-    _import_context_actions: List[ImportContextAction]
-    _symlink_actions: List[SymlinkAction]
     _compile_actions: List[CompileAction]
+    _copy_actions: List[CopyAction]
+    _import_context_actions: List[ImportContextAction]
     _run_actions: List[RunAction]
+    _symlink_actions: List[SymlinkAction]
     _trigger_actions: List[TriggerAction]
 
     def __init__(
@@ -739,10 +740,11 @@ class ActionBlock:
         self.action_block = action_block
 
         for identifier, action_type in (
-            ('import_context', ImportContextAction),
-            ('symlink', SymlinkAction),
             ('compile', CompileAction),
+            ('copy', CopyAction),
+            ('import_context', ImportContextAction),
             ('run', RunAction),
+            ('symlink', SymlinkAction),
             ('trigger', TriggerAction),
         ):
             # Create and persist a list of all ImportContextAction objects
@@ -770,6 +772,11 @@ class ActionBlock:
         """Symlink files."""
         for symlink_action in self._symlink_actions:
             symlink_action.execute()
+
+    def copy(self) -> None:
+        """Copy files."""
+        for copy_action in self._copy_actions:
+            copy_action.execute()
 
     def compile(self) -> None:
         """Compile templates."""

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -720,6 +720,7 @@ class ActionBlock:
     _copy_actions: List[CopyAction]
     _import_context_actions: List[ImportContextAction]
     _run_actions: List[RunAction]
+    _stow_actions: List[StowAction]
     _symlink_actions: List[SymlinkAction]
     _trigger_actions: List[TriggerAction]
 
@@ -745,6 +746,7 @@ class ActionBlock:
             ('import_context', ImportContextAction),
             ('run', RunAction),
             ('symlink', SymlinkAction),
+            ('stow', StowAction),
             ('trigger', TriggerAction),
         ):
             # Create and persist a list of all ImportContextAction objects
@@ -782,6 +784,11 @@ class ActionBlock:
         """Compile templates."""
         for compile_action in self._compile_actions:
             compile_action.execute()
+
+    def stow(self) -> None:
+        """Stow directory contents."""
+        for stow_action in self._stow_actions:
+            stow_action.execute()
 
     def run(
         self,

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -453,6 +453,12 @@ class SymlinkAction(Action):
 
     priority = 200
 
+    def __init__(self, *args, **kwargs) -> None:
+        """Construct symlink action object."""
+        super().__init__(*args, **kwargs)
+        self.symlinked_files: DefaultDict[Path, Set[Path]] = \
+            defaultdict(set)
+
     def execute(self) -> Dict[Path, Path]:
         """
         Symlink to `content` path from `target` path.
@@ -473,6 +479,7 @@ class SymlinkAction(Action):
         for content, symlink in links.items():
             symlink.parent.mkdir(parents=True, exist_ok=True)
             symlink.symlink_to(content)
+            self.symlinked_files[content].add(symlink)
 
         return links
 
@@ -495,6 +502,12 @@ class CopyAction(Action):
     """Copy files Action sub-class."""
 
     priority = 300
+
+    def __init__(self, *args, **kwargs) -> None:
+        """Construct copy action object."""
+        super().__init__(*args, **kwargs)
+        self.copied_files: DefaultDict[Path, Set[Path]] = \
+            defaultdict(set)
 
     def execute(self) -> Dict[Path, Path]:
         """

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -518,6 +518,7 @@ class CopyAction(Action):
         for content, copy in copies.items():
             copy.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy(str(content), str(copy))
+            self.copied_files[content].add(copy)
 
         if permissions:
             for copy in copies.values():
@@ -535,6 +536,10 @@ class CopyAction(Action):
                     )
 
         return copies
+
+    def __contains__(self, other) -> bool:
+        """Return True if path has been copied *from*."""
+        return other in self.copied_files
 
 
 class RunDict(TypedDict):

--- a/astrality/config.py
+++ b/astrality/config.py
@@ -693,7 +693,7 @@ class GlobalModulesConfigDict(TypedDict, total=False):
 
     requires_timeout: Union[int, float]
     run_timeout: Union[int, float]
-    recompile_modified_templates: bool
+    reprocess_modified_files: bool
     modules_directory: str
     enabled_modules: List[EnablingStatement]
 
@@ -713,8 +713,8 @@ class GlobalModulesConfig:
         config_directory: Path,
     ) -> None:
         """Initialize a GlobalModulesConfig object from a dictionary."""
-        self.recompile_modified_templates = config.get(
-            'recompile_modified_templates',
+        self.reprocess_modified_files = config.get(
+            'reprocess_modified_files',
             False,
         )
         self.requires_timeout = config.get(

--- a/astrality/config.py
+++ b/astrality/config.py
@@ -264,7 +264,7 @@ def expand_path(path: Path, config_directory: Path) -> Path:
     expanded to the home directory of $USER.
     """
     # Expand environment variables present in path
-    path = Path(os.path.expandvars(path))
+    path = Path(os.path.expandvars(path))  # type: ignore
 
     # Expand any tilde expressions for user home directory
     path = path.expanduser()

--- a/astrality/config.py
+++ b/astrality/config.py
@@ -263,6 +263,9 @@ def expand_path(path: Path, config_directory: Path) -> Path:
     Relative paths are relative to $ASTRALITY_CONFIG_HOME, and ~ is
     expanded to the home directory of $USER.
     """
+    # Expand environment variables present in path
+    path = Path(os.path.expandvars(path))
+
     # Expand any tilde expressions for user home directory
     path = path.expanduser()
 
@@ -271,10 +274,7 @@ def expand_path(path: Path, config_directory: Path) -> Path:
         path = config_directory / path
 
     # Return path where symlinks such as '..' are resolved
-    path = path.resolve()
-
-    # Expand environment variables and return as a Path object
-    return Path(os.path.expandvars(path))  # type: ignore
+    return path.resolve()
 
 
 def expand_globbed_path(path: Path, config_directory: Path) -> Set[Path]:

--- a/astrality/config.py
+++ b/astrality/config.py
@@ -271,7 +271,7 @@ def expand_path(path: Path, config_directory: Path) -> Path:
 
     # Use config directory as anchor for relative paths
     if not path.is_absolute():
-        path = config_directory / path
+        path = Path(os.path.expandvars(config_directory)) / path  # type: ignore
 
     # Return path where symlinks such as '..' are resolved
     return path.resolve()

--- a/astrality/config/astrality.yml
+++ b/astrality/config/astrality.yml
@@ -40,7 +40,6 @@ config/modules:
         # Module defined in this file
         - name: polybar
         - name: terminals
-        - name: dotfiles
 
         # All modules defined in <modules_directory>/solar_desktop/config.yml
         - name: solar_desktop::*
@@ -58,8 +57,7 @@ module/dotfiles:
         compile:
             content: $XDG_CONFIG_HOME
             target: $XDG_CONFIG_HOME
-            templates: 'template\.(.+)'
-            non_templates: ignore
+            include: 'template\.(.+)'
 
 
 

--- a/astrality/config/astrality.yml
+++ b/astrality/config/astrality.yml
@@ -21,8 +21,9 @@ config/modules:
     # commands to exit.
     run_timeout: 0
 
-    # Modified templates can be automatically recompiled.
-    recompile_modified_templates: true
+    # Modified templates can be automatically recompiled. This also includes
+    # files that have been copied to a target destination.
+    reprocess_modified_files: true
 
     # There are two possible ways to define modules. Either in this file, as
     # shown further below, or in separate external module directories within the

--- a/astrality/config/astrality.yml
+++ b/astrality/config/astrality.yml
@@ -40,6 +40,7 @@ config/modules:
         # Module defined in this file
         - name: polybar
         - name: terminals
+        - name: dotfiles
 
         # All modules defined in <modules_directory>/solar_desktop/config.yml
         - name: solar_desktop::*
@@ -55,7 +56,7 @@ module/dotfiles:
     # placing it in the same directory as the template.
     on_startup:
         compile:
-            source: $XDG_CONFIG_HOME
+            content: $XDG_CONFIG_HOME
             target: $XDG_CONFIG_HOME
             templates: 'template\.(.+)'
             non_templates: ignore
@@ -155,7 +156,7 @@ module/polybar:
 
     on_startup:
         compile:
-            - source: modules/polybar/config.template
+            - content: modules/polybar/config.template
 
         run:
             - shell: killall -q polybar
@@ -165,7 +166,7 @@ module/polybar:
     on_modified:
         modules/polybar/config.template:
             compile:
-                - source: modules/polybar/config.template
+                - content: modules/polybar/config.template
 
 
 module/terminals:
@@ -189,7 +190,7 @@ module/terminals:
 
     on_startup:
         compile:
-            - source: modules/terminals/alacritty.yml.template
+            - content: modules/terminals/alacritty.yml.template
               target: {{ env.XDG_CONFIG_HOME }}/alacritty/alacritty.yml
-            - source: modules/terminals/kitty.conf.template
+            - content: modules/terminals/kitty.conf.template
               target: {{ env.XDG_CONFIG_HOME }}/kitty/kitty.conf

--- a/astrality/config/astrality.yml
+++ b/astrality/config/astrality.yml
@@ -49,6 +49,19 @@ config/modules:
           autoupdate: true  # Fetch new color schemes as they are added
 
 
+module/dotfiles:
+    # This module automatically compiles all filenames within $XDG_CONFIG_HOME
+    # prefixed with 'template.'. It removes the prefix for the compile target,
+    # placing it in the same directory as the template.
+    on_startup:
+        compile:
+            source: $XDG_CONFIG_HOME
+            target: $XDG_CONFIG_HOME
+            templates: 'template\.(.+)'
+            non_templates: ignore
+
+
+
 context/host:
     # Here we define some context values which often change between host
     # computers, and are therefore practical to use in our templates.

--- a/astrality/config/modules/solar_desktop/config.yml
+++ b/astrality/config/modules/solar_desktop/config.yml
@@ -61,8 +61,8 @@ module/solar_desktop:
         # Compile the templates specified in the conky module, as their
         # context values have changed due to the import_context action above.
         compile:
-            - source: time.template
-            - source: performance.template
+            - content: time.template
+            - content: performance.template
 
         # Run shell command to change the desktop wallpaper named the same
         # as the current event.

--- a/astrality/module.py
+++ b/astrality/module.py
@@ -741,7 +741,6 @@ class ModuleManager:
 
         Also close all temporary file handlers created by the modules.
         """
-        # First import context, symlink, and compile templates
         self.import_context_sections('on_exit')
         self.symlink('on_exit')
         self.copy('on_exit')
@@ -869,6 +868,15 @@ class ModuleManager:
                 for compile_action in action_block._compile_actions:
                     if modified in compile_action:
                         compile_action.execute()
+
+                for stow_action in action_block._stow_actions:
+                    if modified in stow_action:
+                        stow_action.execute()
+
+                # TODO: Test this branch
+                for copy_action in action_block._copy_actions:
+                    if modified in copy_action:
+                        copy_action.execute()
 
     def interpolate_string(self, string: str) -> str:
         """

--- a/astrality/module.py
+++ b/astrality/module.py
@@ -407,8 +407,8 @@ class ModuleManager:
             config=config.get('config/modules', {}),
             config_directory=self.config_directory,
         )
-        self.recompile_modified_templates = \
-            self.global_modules_config.recompile_modified_templates
+        self.reprocess_modified_files = \
+            self.global_modules_config.reprocess_modified_files
 
         self.modules: Dict[str, Module] = {}
 
@@ -748,9 +748,9 @@ class ModuleManager:
         Recompile any modified template if configured.
 
         This requires setting the global setting:
-        recompile_modified_templates: true
+        reprocess_modified_files: true
         """
-        if not self.recompile_modified_templates:
+        if not self.reprocess_modified_files:
             return
 
         # Run any compile action a new if that compile action uses the modifed

--- a/astrality/module.py
+++ b/astrality/module.py
@@ -155,12 +155,11 @@ class Module:
                 path=Path(path_string),
                 config_directory=self.directory,
             )
-            action_blocks['on_modified'][modified_path] = \
-                ActionBlock(
-                    action_block=action_block_dict,
-                    directory=self.directory,
-                    replacer=self.interpolate_string,
-                    context_store=self.context_store,
+            action_blocks['on_modified'][modified_path] = ActionBlock(
+                action_block=action_block_dict,
+                directory=self.directory,
+                replacer=self.interpolate_string,
+                context_store=self.context_store,
             )
         self.action_blocks = action_blocks
 
@@ -201,6 +200,28 @@ class Module:
         triggers = action_block.triggers()
         for trigger in triggers:
             self.import_context(
+                block_name=trigger.block,
+                path=trigger.absolute_path,
+            )
+
+    def symlink(
+        self,
+        block_name: str,
+        path: Optional[Path] = None,
+    ) -> None:
+        """
+        Execute all symlink actions specified in block_name[:path].
+
+        :param block_name: Name of block such as 'on_startup'.
+        :param path: Absolute path in case of block_name == 'on_modified'.
+        """
+        action_block = self.get_action_block(name=block_name, path=path)
+        action_block.symlink()
+
+        # Symlink from triggered action blocks
+        triggers = action_block.triggers()
+        for trigger in triggers:
+            self.symlink(
                 block_name=trigger.block,
                 path=trigger.absolute_path,
             )

--- a/astrality/module.py
+++ b/astrality/module.py
@@ -226,6 +226,28 @@ class Module:
                 path=trigger.absolute_path,
             )
 
+    def copy(
+        self,
+        block_name: str,
+        path: Optional[Path] = None,
+    ) -> None:
+        """
+        Execute all copy actions specified in block_name[:path].
+
+        :param block_name: Name of block such as 'on_startup'.
+        :param path: Absolute path in case of block_name == 'on_modified'.
+        """
+        action_block = self.get_action_block(name=block_name, path=path)
+        action_block.copy()
+
+        # Symlink from triggered action blocks
+        triggers = action_block.triggers()
+        for trigger in triggers:
+            self.copy(
+                block_name=trigger.block,
+                path=trigger.absolute_path,
+            )
+
     def compile(
         self,
         block_name: str,

--- a/astrality/module.py
+++ b/astrality/module.py
@@ -270,6 +270,28 @@ class Module:
                 path=trigger.absolute_path,
             )
 
+    def stow(
+        self,
+        block_name: str,
+        path: Optional[Path] = None,
+    ) -> None:
+        """
+        Execute all stow actions specified in block_name[:path].
+
+        :param block_name: Name of block such as 'on_startup'.
+        :param path: Absolute path in case of block_name == 'on_modified'.
+        """
+        action_block = self.get_action_block(name=block_name, path=path)
+        action_block.stow()
+
+        # Symlink from triggered action blocks
+        triggers = action_block.triggers()
+        for trigger in triggers:
+            self.stow(
+                block_name=trigger.block,
+                path=trigger.absolute_path,
+            )
+
     def run(
         self,
         block_name: str,

--- a/astrality/tests/actions/test_action_block.py
+++ b/astrality/tests/actions/test_action_block.py
@@ -150,3 +150,22 @@ def test_symlinking(action_block_factory, create_temp_files):
 
     # Existing files should be backed up
     assert Path(str(file2) + '.bak').read_text() == 'original'
+
+
+def test_copying(action_block_factory, create_temp_files):
+    """Action blocks should copy properly."""
+    file1, file2, file3, file4 = create_temp_files(4)
+    file2.write_text('original')
+    file4.write_text('some other content')
+
+    action_block = action_block_factory(
+        copy=[
+            {'content': str(file1), 'target': str(file2)},
+            {'content': str(file3), 'target': str(file4)},
+        ],
+    )
+    action_block.copy()
+
+    # Check if content has been copied
+    assert file2.read_text() == file1.read_text()
+    assert file4.read_text() == file3.read_text()

--- a/astrality/tests/actions/test_action_block.py
+++ b/astrality/tests/actions/test_action_block.py
@@ -128,3 +128,25 @@ def test_retrieving_all_compiled_templates(template_directory, tmpdir):
         template1: {target1, target2},
         template2: {target3},
     }
+
+
+def test_symlinking(action_block_factory, create_temp_files):
+    """Action blocks should symlink properly."""
+    file1, file2, file3, file4 = create_temp_files(4)
+    file2.write_text('original')
+
+    action_block = action_block_factory(
+        symlink=[
+            {'content': str(file1), 'target': str(file2)},
+            {'content': str(file3), 'target': str(file4)},
+        ],
+    )
+    action_block.symlink()
+
+    assert file2.is_symlink()
+    assert file2.resolve() == file1
+    assert file4.is_symlink()
+    assert file4.resolve() == file3
+
+    # Existing files should be backed up
+    assert Path(str(file2) + '.bak').read_text() == 'original'

--- a/astrality/tests/actions/test_action_block.py
+++ b/astrality/tests/actions/test_action_block.py
@@ -42,7 +42,7 @@ def test_executing_several_action_blocks(test_config_directory, tmpdir):
     action_block_dict = {
         'import_context': {'from_path': 'context/mercedes.yml'},
         'compile': [{
-            'source': 'templates/a_car.template',
+            'content': 'templates/a_car.template',
             'target': str(target),
         }],
         'run': {'shell': 'touch ' + str(touched)},
@@ -108,9 +108,9 @@ def test_retrieving_all_compiled_templates(template_directory, tmpdir):
 
     action_block_dict = {
         'compile': [
-            {'source': str(template1), 'target': str(target1)},
-            {'source': str(template1), 'target': str(target2)},
-            {'source': str(template2), 'target': str(target3)},
+            {'content': str(template1), 'target': str(target1)},
+            {'content': str(template1), 'target': str(target2)},
+            {'content': str(template2), 'target': str(target3)},
         ],
     }
 

--- a/astrality/tests/actions/test_action_block.py
+++ b/astrality/tests/actions/test_action_block.py
@@ -169,3 +169,27 @@ def test_copying(action_block_factory, create_temp_files):
     # Check if content has been copied
     assert file2.read_text() == file1.read_text()
     assert file4.read_text() == file3.read_text()
+
+
+def test_stowing(action_block_factory, create_temp_files):
+    """Action blocks should stow properly."""
+    template, target = create_temp_files(2)
+    template.write_text('{{ env.EXAMPLE_ENV_VARIABLE }}')
+    symlink_target = template.parent / 'symlink_me'
+    symlink_target.touch()
+
+    action_block = action_block_factory(
+        stow={
+            'content': str(template.parent),
+            'target': str(target.parent),
+            'templates': r'file(0).temp',
+            'non_templates': 'symlink',
+        },
+    )
+    action_block.stow()
+
+    # Check if template has been compiled
+    assert Path(target.parent / '0').read_text() == 'test_value'
+
+    # Check if non_template has been symlinked
+    assert (template.parent / 'symlink_me').resolve() == symlink_target

--- a/astrality/tests/actions/test_compile_action.py
+++ b/astrality/tests/actions/test_compile_action.py
@@ -294,6 +294,32 @@ def test_filtering_compiled_templates(test_config_directory, tmpdir):
     assert (temp_dir / 'module.template').is_file()
     assert (temp_dir / 'recursive' / 'empty.template').is_file()
 
+def test_renaming_templates(test_config_directory, tmpdir):
+    """Templates targets should be renameable with a capture group."""
+    temp_dir = Path(tmpdir)
+    templates = \
+        test_config_directory / 'test_modules' / 'using_all_actions'
+
+    # Multiple capture groups should be allowed
+    compile_dict = {
+        'source': str(templates),
+        'target': str(temp_dir),
+        'templates': r'(?:^template\.(.+)$|^(.+)\.template$)',
+    }
+    compile_action = CompileAction(
+        options=compile_dict,
+        directory=test_config_directory,
+        replacer=lambda x: x,
+        context_store={'geography': {'capitol': 'Berlin'}},
+    )
+    compile_action.execute()
+
+    # We should have a total of two compiled files
+    assert len(list(temp_dir.iterdir())) == 2
+    assert len(list((temp_dir / 'recursive').iterdir())) == 1
+    assert (temp_dir / 'module').is_file()
+    assert (temp_dir / 'recursive' / 'empty').is_file()
+
 @pytest.mark.skip(reason='Glob paths have not been implemented yet')
 def test_compiling_entire_directory_with_single_glob(  # pragma: no cover
     test_config_directory,

--- a/astrality/tests/actions/test_compile_action.py
+++ b/astrality/tests/actions/test_compile_action.py
@@ -270,6 +270,30 @@ def test_compiling_entire_directory(test_config_directory, tmpdir):
     assert temp_dir / 'module.template' in target_dir_content
     assert (temp_dir / 'recursive' / 'empty.template').is_file()
 
+def test_filtering_compiled_templates(test_config_directory, tmpdir):
+    """Users should be able to restrict compilable templates."""
+    temp_dir = Path(tmpdir)
+    templates = \
+        test_config_directory / 'test_modules' / 'using_all_actions'
+    compile_dict = {
+        'source': str(templates),
+        'target': str(temp_dir),
+        'templates': r'.+\.template',
+    }
+    compile_action = CompileAction(
+        options=compile_dict,
+        directory=test_config_directory,
+        replacer=lambda x: x,
+        context_store={'geography': {'capitol': 'Berlin'}},
+    )
+    compile_action.execute()
+
+    # We should have a total of two compiled files
+    assert len(list(temp_dir.iterdir())) == 2
+    assert len(list((temp_dir / 'recursive').iterdir())) == 1
+    assert (temp_dir / 'module.template').is_file()
+    assert (temp_dir / 'recursive' / 'empty.template').is_file()
+
 @pytest.mark.skip(reason='Glob paths have not been implemented yet')
 def test_compiling_entire_directory_with_single_glob(  # pragma: no cover
     test_config_directory,

--- a/astrality/tests/actions/test_compile_action.py
+++ b/astrality/tests/actions/test_compile_action.py
@@ -7,6 +7,7 @@ import pytest
 
 from astrality.actions import CompileAction
 
+
 def test_null_object_pattern():
     """Compilation action with no parameters should be a null object."""
     compile_action = CompileAction(
@@ -22,7 +23,7 @@ def test_null_object_pattern():
 def test_compilation_of_template_to_temporary_file(template_directory):
     """Compile template to temporary file in absence of `target`."""
     compile_dict = {
-        'source': 'no_context.template',
+        'content': 'no_context.template',
     }
     compile_action = CompileAction(
         options=compile_dict,
@@ -36,6 +37,7 @@ def test_compilation_of_template_to_temporary_file(template_directory):
     assert template in compilations
     assert compilations[template].read_text() == 'one\ntwo\nthree'
 
+
 def test_compilation_to_specific_absolute_file_path(template_directory, tmpdir):
     """
     Compile to specified absolute target path.
@@ -44,7 +46,7 @@ def test_compilation_to_specific_absolute_file_path(template_directory, tmpdir):
     """
     target = Path(tmpdir) / 'target'
     compile_dict = {
-        'source': 'no_context.template',
+        'content': 'no_context.template',
         'target': str(target),
     }
     compile_action = CompileAction(
@@ -58,6 +60,7 @@ def test_compilation_to_specific_absolute_file_path(template_directory, tmpdir):
     assert return_target == target
     assert target.read_text() == 'one\ntwo\nthree'
 
+
 def test_compilation_to_specific_relative_file_path(template_directory, tmpdir):
     """
     Compile to specified absolute target path.
@@ -66,7 +69,7 @@ def test_compilation_to_specific_relative_file_path(template_directory, tmpdir):
     """
     target = Path(tmpdir) / 'target'
     compile_dict = {
-        'source': str(template_directory / 'no_context.template'),
+        'content': str(template_directory / 'no_context.template'),
         'target': str(target.name),
     }
     compile_action = CompileAction(
@@ -80,6 +83,7 @@ def test_compilation_to_specific_relative_file_path(template_directory, tmpdir):
     assert return_target == target
     assert target.read_text() == 'one\ntwo\nthree'
 
+
 def test_compilation_with_context(template_directory):
     """
     Templates should be compiled with the context store.
@@ -87,7 +91,7 @@ def test_compilation_with_context(template_directory):
     It should compile differently after mutatinig the store.
     """
     compile_dict = {
-        'source': 'test_template.conf',
+        'content': 'test_template.conf',
     }
     context_store = {}
 
@@ -108,10 +112,11 @@ def test_compilation_with_context(template_directory):
     target = list(compile_action.execute().values())[0]
     assert target.read_text() == f'some text\n{username}\nTimesNewRoman'
 
+
 def test_setting_permissions_of_target_template(template_directory):
     """Template target permission bits should be settable."""
     compile_dict = {
-        'source': 'empty.template',
+        'content': 'empty.template',
         'permissions': '707',
     }
     compile_action = CompileAction(
@@ -124,10 +129,11 @@ def test_setting_permissions_of_target_template(template_directory):
     target = list(compile_action.execute().values())[0]
     assert (target.stat().st_mode & 0o777) == 0o707
 
+
 def test_use_of_replacer(template_directory, tmpdir):
     """All options should be run through the replacer."""
     compile_dict = {
-        'source': 'template',
+        'content': 'template',
         'target': 'target',
         'permissions': 'permissions',
     }
@@ -155,10 +161,11 @@ def test_use_of_replacer(template_directory, tmpdir):
     assert target.read_text() == 'one\ntwo\nthree'
     assert (target.stat().st_mode & 0o777) == 0o777
 
+
 def test_that_current_directory_is_set_correctly(template_directory):
     """Shell commmand filters should be run from `directory`."""
     compile_dict = {
-        'source': str(
+        'content': str(
             template_directory / 'shell_filter_working_directory.template',
         ),
     }
@@ -173,13 +180,14 @@ def test_that_current_directory_is_set_correctly(template_directory):
     target = list(compile_action.execute().values())[0]
     assert target.read_text() == '/tmp'
 
+
 def test_retrieving_all_compiled_templates(template_directory, tmpdir):
     """Compile actions should return all compiled templates."""
     target1, target2 = Path(tmpdir) / 'target.tmp', Path(tmpdir) / 'target2'
     targets = [target1, target2]
     template = Path('no_context.template')
     compile_dict = {
-        'source': str(template),
+        'content': str(template),
         'target': '{target}',
     }
 
@@ -205,11 +213,12 @@ def test_retrieving_all_compiled_templates(template_directory, tmpdir):
         template_directory / template: {target1, target2},
     }
 
+
 def test_contains_special_method(template_directory, tmpdir):
     """Compile actions should 'contain' its compiled template."""
     temp_dir = Path(tmpdir)
     compile_dict = {
-        'source': 'empty.template',
+        'content': 'empty.template',
         'permissions': '707',
         'target': str(temp_dir / 'target.tmp'),
     }
@@ -223,11 +232,12 @@ def test_contains_special_method(template_directory, tmpdir):
     assert template_directory / 'empty.template' in compile_action
     assert Path('/no/template') not in compile_action
 
+
 def test_contains_with_uncompiled_template(template_directory, tmpdir):
     """Compile action only contains *compiled* templates."""
     temp_dir = Path(tmpdir)
     compile_dict = {
-        'source': 'empty.template',
+        'content': 'empty.template',
         'permissions': '707',
         'target': str(temp_dir / 'target.tmp'),
     }
@@ -242,13 +252,14 @@ def test_contains_with_uncompiled_template(template_directory, tmpdir):
     compile_action.execute()
     assert template_directory / 'empty.template' in compile_action
 
+
 def test_compiling_entire_directory(test_config_directory, tmpdir):
     """All directory contents should be recursively compiled."""
     temp_dir = Path(tmpdir)
     templates = \
         test_config_directory / 'test_modules' / 'using_all_actions'
     compile_dict = {
-        'source': str(templates),
+        'content': str(templates),
         'target': str(temp_dir),
     }
     compile_action = CompileAction(
@@ -270,13 +281,14 @@ def test_compiling_entire_directory(test_config_directory, tmpdir):
     assert temp_dir / 'module.template' in target_dir_content
     assert (temp_dir / 'recursive' / 'empty.template').is_file()
 
+
 def test_filtering_compiled_templates(test_config_directory, tmpdir):
     """Users should be able to restrict compilable templates."""
     temp_dir = Path(tmpdir)
     templates = \
         test_config_directory / 'test_modules' / 'using_all_actions'
     compile_dict = {
-        'source': str(templates),
+        'content': str(templates),
         'target': str(temp_dir),
         'templates': r'.+\.template',
         'non_templates': 'ignore',
@@ -295,6 +307,7 @@ def test_filtering_compiled_templates(test_config_directory, tmpdir):
     assert (temp_dir / 'module.template').is_file()
     assert (temp_dir / 'recursive' / 'empty.template').is_file()
 
+
 def test_renaming_templates(test_config_directory, tmpdir):
     """Templates targets should be renameable with a capture group."""
     temp_dir = Path(tmpdir)
@@ -303,7 +316,7 @@ def test_renaming_templates(test_config_directory, tmpdir):
 
     # Multiple capture groups should be allowed
     compile_dict = {
-        'source': str(templates),
+        'content': str(templates),
         'target': str(temp_dir),
         'templates': r'(?:^template\.(.+)$|^(.+)\.template$)',
         'non_templates': 'ignore',
@@ -322,13 +335,14 @@ def test_renaming_templates(test_config_directory, tmpdir):
     assert (temp_dir / 'module').is_file()
     assert (temp_dir / 'recursive' / 'empty').is_file()
 
+
 def test_symlinking_non_templates(test_config_directory, tmpdir):
     """Non-templates files should be implicitly symlinked."""
     temp_dir = Path(tmpdir)
     templates = \
         test_config_directory / 'test_modules' / 'using_all_actions'
     compile_dict = {
-        'source': str(templates),
+        'content': str(templates),
         'target': str(temp_dir),
         'templates': r'.+\.template',
     }
@@ -353,13 +367,14 @@ def test_symlinking_non_templates(test_config_directory, tmpdir):
     # Symlinked files should be considered as "compiled templates"
     assert templates / 'config.yml' in compile_action.performed_compilations()
 
+
 def test_copying_non_template_files(test_config_directory, tmpdir):
     """Non-templates files can be copied."""
     temp_dir = Path(tmpdir)
     templates = \
         test_config_directory / 'test_modules' / 'using_all_actions'
     compile_dict = {
-        'source': str(templates),
+        'content': str(templates),
         'target': str(temp_dir),
         'templates': r'.+\.template',
         'non_templates': 'copy',
@@ -370,7 +385,7 @@ def test_copying_non_template_files(test_config_directory, tmpdir):
         replacer=lambda x: x,
         context_store={'geography': {'capitol': 'Berlin'}},
     )
-    results = compile_action.execute()
+    compile_action.execute()
 
     # Templates should still compiled
     target_dir_content = list(temp_dir.iterdir())
@@ -386,6 +401,7 @@ def test_copying_non_template_files(test_config_directory, tmpdir):
     # Copied files should be considered as "compiled templates"
     assert templates / 'config.yml' in compile_action.performed_compilations()
 
+
 @pytest.mark.skip(reason='Glob paths have not been implemented yet')
 def test_compiling_entire_directory_with_single_glob(  # pragma: no cover
     test_config_directory,
@@ -395,7 +411,7 @@ def test_compiling_entire_directory_with_single_glob(  # pragma: no cover
     temp_dir = Path(tmpdir)
     templates = test_config_directory / 'test_modules' / 'using_all_actions'
     compile_dict = {
-        'source': str(templates / '*'),
+        'content': str(templates / '*'),
         'target': str(temp_dir),
     }
     compile_action = CompileAction(

--- a/astrality/tests/actions/test_compile_action.py
+++ b/astrality/tests/actions/test_compile_action.py
@@ -279,6 +279,7 @@ def test_filtering_compiled_templates(test_config_directory, tmpdir):
         'source': str(templates),
         'target': str(temp_dir),
         'templates': r'.+\.template',
+        'non_templates': 'ignore',
     }
     compile_action = CompileAction(
         options=compile_dict,
@@ -305,6 +306,7 @@ def test_renaming_templates(test_config_directory, tmpdir):
         'source': str(templates),
         'target': str(temp_dir),
         'templates': r'(?:^template\.(.+)$|^(.+)\.template$)',
+        'non_templates': 'ignore',
     }
     compile_action = CompileAction(
         options=compile_dict,
@@ -319,6 +321,70 @@ def test_renaming_templates(test_config_directory, tmpdir):
     assert len(list((temp_dir / 'recursive').iterdir())) == 1
     assert (temp_dir / 'module').is_file()
     assert (temp_dir / 'recursive' / 'empty').is_file()
+
+def test_symlinking_non_templates(test_config_directory, tmpdir):
+    """Non-templates files should be implicitly symlinked."""
+    temp_dir = Path(tmpdir)
+    templates = \
+        test_config_directory / 'test_modules' / 'using_all_actions'
+    compile_dict = {
+        'source': str(templates),
+        'target': str(temp_dir),
+        'templates': r'.+\.template',
+    }
+    compile_action = CompileAction(
+        options=compile_dict,
+        directory=test_config_directory,
+        replacer=lambda x: x,
+        context_store={'geography': {'capitol': 'Berlin'}},
+    )
+    results = compile_action.execute()
+
+    # Templates should still compiled
+    target_dir_content = list(temp_dir.iterdir())
+    assert len(target_dir_content) == 6
+    assert temp_dir / 'module.template' in target_dir_content
+    assert (temp_dir / 'recursive' / 'empty.template').is_file()
+
+    # The rest should be symlinked
+    assert (temp_dir / 'config.yml').is_symlink()
+    assert (temp_dir / 'config.yml').resolve() == templates / 'config.yml'
+
+    # Symlinked files should be considered as "compiled templates"
+    assert templates / 'config.yml' in compile_action.performed_compilations()
+
+def test_copying_non_template_files(test_config_directory, tmpdir):
+    """Non-templates files can be copied."""
+    temp_dir = Path(tmpdir)
+    templates = \
+        test_config_directory / 'test_modules' / 'using_all_actions'
+    compile_dict = {
+        'source': str(templates),
+        'target': str(temp_dir),
+        'templates': r'.+\.template',
+        'non_templates': 'copy',
+    }
+    compile_action = CompileAction(
+        options=compile_dict,
+        directory=test_config_directory,
+        replacer=lambda x: x,
+        context_store={'geography': {'capitol': 'Berlin'}},
+    )
+    results = compile_action.execute()
+
+    # Templates should still compiled
+    target_dir_content = list(temp_dir.iterdir())
+    assert len(target_dir_content) == 6
+    assert temp_dir / 'module.template' in target_dir_content
+    assert (temp_dir / 'recursive' / 'empty.template').is_file()
+
+    # The rest should be symlinked
+    assert (temp_dir / 'config.yml').is_file()
+    assert (temp_dir / 'config.yml').read_text() == \
+        (templates / 'config.yml').read_text()
+
+    # Copied files should be considered as "compiled templates"
+    assert templates / 'config.yml' in compile_action.performed_compilations()
 
 @pytest.mark.skip(reason='Glob paths have not been implemented yet')
 def test_compiling_entire_directory_with_single_glob(  # pragma: no cover

--- a/astrality/tests/actions/test_copy_action.py
+++ b/astrality/tests/actions/test_copy_action.py
@@ -1,0 +1,136 @@
+"""Tests for astrality.actions.CopyAction."""
+
+from pathlib import Path
+
+from astrality.actions import CopyAction
+
+
+def test_copy_action_using_all_parameters(tmpdir):
+    """All three parameters should be respected."""
+    temp_dir = Path(tmpdir) / 'content'
+    temp_dir.mkdir()
+
+    target = Path(tmpdir) / 'target'
+    target.mkdir()
+
+    file1 = temp_dir / 'file1'
+    file1.write_text('file1 content')
+
+    file2 = temp_dir / 'file2'
+    file2.write_text('file2 content')
+
+    recursive_dir = temp_dir / 'recursive'
+    recursive_dir.mkdir()
+
+    file3 = temp_dir / 'recursive' / 'file3'
+    file3.write_text('file3 content')
+
+    copy_options = {
+        'content': str(temp_dir),
+        'target': str(target),
+        'include': r'file(\d)',
+    }
+    copy_action = CopyAction(
+        options=copy_options,
+        directory=temp_dir,
+        replacer=lambda x: x,
+        context_store={},
+    )
+    copy_action.execute()
+
+    assert (target / '1').read_text() == file1.read_text()
+    assert (target / '2').read_text() == file2.read_text()
+    assert (target / 'recursive' / '3').read_text() == file3.read_text()
+
+
+def test_copying_without_renaming(tmpdir):
+    """When include is not given, keep copy name."""
+    temp_dir = Path(tmpdir) / 'content'
+    temp_dir.mkdir()
+
+    target = Path(tmpdir) / 'target'
+    target.mkdir()
+
+    file1 = temp_dir / 'file1'
+    file1.touch()
+
+    file2 = temp_dir / 'file2'
+    file2.touch()
+
+    recursive_dir = temp_dir / 'recursive'
+    recursive_dir.mkdir()
+
+    file3 = temp_dir / 'recursive' / 'file3'
+    file3.touch()
+
+    copy_options = {
+        'content': str(temp_dir),
+        'target': str(target),
+    }
+    copy_action = CopyAction(
+        options=copy_options,
+        directory=temp_dir,
+        replacer=lambda x: x,
+        context_store={},
+    )
+    copy_action.execute()
+
+    assert (target / 'file1').read_text() == file1.read_text()
+    assert (target / 'file2').read_text() == file2.read_text()
+    assert (target / 'recursive' / 'file3').read_text() == file3.read_text()
+
+
+def test_copying_file_to_directory(tmpdir):
+    """If copying from directory to file, place file in directory."""
+    temp_dir = Path(tmpdir) / 'content'
+    temp_dir.mkdir()
+
+    target = Path(tmpdir) / 'target'
+    target.mkdir()
+
+    file1 = temp_dir / 'file1'
+    file1.touch()
+
+    copy_options = {
+        'content': str(file1),
+        'target': str(target),
+        'include': r'file1',
+    }
+    copy_action = CopyAction(
+        options=copy_options,
+        directory=temp_dir,
+        replacer=lambda x: x,
+        context_store={},
+    )
+    copy_action.execute()
+
+    assert (target / 'file1').read_text() == file1.read_text()
+
+
+def test_setting_permissions_on_target_copy(tmpdir):
+    """If permissions is provided, use it for the target."""
+    temp_dir = Path(tmpdir) / 'content'
+    temp_dir.mkdir()
+
+    target = Path(tmpdir) / 'target'
+    target.mkdir()
+
+    file1 = temp_dir / 'file1'
+    file1.touch()
+    file1.chmod(0o770)
+
+    copy_options = {
+        'content': str(file1),
+        'target': str(target),
+        'include': r'file1',
+        'permissions': '777',
+    }
+    copy_action = CopyAction(
+        options=copy_options,
+        directory=temp_dir,
+        replacer=lambda x: x,
+        context_store={},
+    )
+    copy_action.execute()
+
+    assert ((target / 'file1').stat().st_mode & 0o000777) == 0o777

--- a/astrality/tests/actions/test_copy_action.py
+++ b/astrality/tests/actions/test_copy_action.py
@@ -5,6 +5,17 @@ from pathlib import Path
 from astrality.actions import CopyAction
 
 
+def test_null_object_pattern():
+    """Copy actions without options should do nothing."""
+    copy_action = CopyAction(
+        options={},
+        directory=Path('/'),
+        replacer=lambda x: x,
+        context_store={},
+    )
+    copy_action.execute()
+
+
 def test_copy_action_using_all_parameters(tmpdir):
     """All three parameters should be respected."""
     temp_dir = Path(tmpdir) / 'content'

--- a/astrality/tests/actions/test_copy_action.py
+++ b/astrality/tests/actions/test_copy_action.py
@@ -52,6 +52,12 @@ def test_copy_action_using_all_parameters(tmpdir):
     assert (target / '1').read_text() == file1.read_text()
     assert (target / '2').read_text() == file2.read_text()
     assert (target / 'recursive' / '3').read_text() == file3.read_text()
+    assert copy_action.copied_files == {
+        file1: {target / '1'},
+        file2: {target / '2'},
+        file3: {target / 'recursive' / '3'},
+    }
+    assert file1 in copy_action
 
 
 def test_copying_without_renaming(tmpdir):

--- a/astrality/tests/actions/test_stow_action.py
+++ b/astrality/tests/actions/test_stow_action.py
@@ -1,0 +1,139 @@
+"""Tests for astrality.actions.StowAction."""
+
+from pathlib import Path
+
+from astrality.actions import StowAction
+
+
+def test_null_object_pattern():
+    """Copy actions without options should do nothing."""
+    stow_action = StowAction(
+        options={},
+        directory=Path('/'),
+        replacer=lambda x: x,
+        context_store={},
+    )
+    stow_action.execute()
+
+
+def test_filtering_stowed_templates(test_config_directory, tmpdir):
+    """Users should be able to restrict compilable templates with ignore."""
+    temp_dir = Path(tmpdir)
+    templates = \
+        test_config_directory / 'test_modules' / 'using_all_actions'
+    stow_dict = {
+        'content': str(templates),
+        'target': str(temp_dir),
+        'templates': r'.+\.template',
+        'non_templates': 'ignore',
+    }
+    stow_action = StowAction(
+        options=stow_dict,
+        directory=test_config_directory,
+        replacer=lambda x: x,
+        context_store={'geography': {'capitol': 'Berlin'}},
+    )
+    stow_action.execute()
+
+    # We should have a total of two stowed files
+    assert len(list(temp_dir.iterdir())) == 2
+    assert len(list((temp_dir / 'recursive').iterdir())) == 1
+    assert (temp_dir / 'module.template').is_file()
+    assert (temp_dir / 'recursive' / 'empty.template').is_file()
+
+
+def test_renaming_templates(test_config_directory, tmpdir):
+    """Templates targets should be renameable with a capture group."""
+    temp_dir = Path(tmpdir)
+    templates = \
+        test_config_directory / 'test_modules' / 'using_all_actions'
+
+    # Multiple capture groups should be allowed
+    stow_dict = {
+        'content': str(templates),
+        'target': str(temp_dir),
+        'templates': r'(?:^template\.(.+)$|^(.+)\.template$)',
+        'non_templates': 'ignore',
+    }
+    stow_action = StowAction(
+        options=stow_dict,
+        directory=test_config_directory,
+        replacer=lambda x: x,
+        context_store={'geography': {'capitol': 'Berlin'}},
+    )
+    stow_action.execute()
+
+    # We should have a total of two stowed files
+    assert len(list(temp_dir.iterdir())) == 2
+    assert len(list((temp_dir / 'recursive').iterdir())) == 1
+    assert (temp_dir / 'module').is_file()
+    assert (temp_dir / 'recursive' / 'empty').is_file()
+
+
+def test_symlinking_non_templates(test_config_directory, tmpdir):
+    """Non-templates files should be implicitly symlinked."""
+    temp_dir = Path(tmpdir)
+    templates = \
+        test_config_directory / 'test_modules' / 'using_all_actions'
+    stow_dict = {
+        'content': str(templates),
+        'target': str(temp_dir),
+        'templates': r'.+\.template',
+    }
+    stow_action = StowAction(
+        options=stow_dict,
+        directory=test_config_directory,
+        replacer=lambda x: x,
+        context_store={'geography': {'capitol': 'Berlin'}},
+    )
+    stow_action.execute()
+
+    # Templates should still stowed
+    target_dir_content = list(temp_dir.iterdir())
+    assert len(target_dir_content) == 6
+    assert temp_dir / 'module.template' in target_dir_content
+    assert not (temp_dir / 'module.template').is_symlink()
+    assert (temp_dir / 'recursive' / 'empty.template').is_file()
+
+    # The rest should be symlinked
+    assert (temp_dir / 'config.yml').is_symlink()
+    assert (temp_dir / 'config.yml').resolve() == templates / 'config.yml'
+
+    # Symlinked files should be not considered as a managed file, as it is
+    # self-updating.
+    assert templates / 'config.yml' not in stow_action.managed_files()
+
+
+def test_copying_non_template_files(test_config_directory, tmpdir):
+    """Non-templates files can be copied."""
+    temp_dir = Path(tmpdir)
+    templates = \
+        test_config_directory / 'test_modules' / 'using_all_actions'
+    stow_dict = {
+        'content': str(templates),
+        'target': str(temp_dir),
+        'templates': r'.+\.template',
+        'non_templates': 'copy',
+    }
+    stow_action = StowAction(
+        options=stow_dict,
+        directory=test_config_directory,
+        replacer=lambda x: x,
+        context_store={'geography': {'capitol': 'Berlin'}},
+    )
+    stow_action.execute()
+
+    # Templates should still stowed
+    target_dir_content = list(temp_dir.iterdir())
+    assert len(target_dir_content) == 6
+    assert temp_dir / 'module.template' in target_dir_content
+    assert (temp_dir / 'recursive' / 'empty.template').is_file()
+
+    # The rest should be copied
+    assert (temp_dir / 'config.yml').is_file()
+    assert (temp_dir / 'config.yml').read_text() == \
+        (templates / 'config.yml').read_text()
+
+    # Copied files should be considered as a managed file, as it needs to be
+    # copied again if modified.
+    assert templates / 'config.yml' in stow_action.managed_files()

--- a/astrality/tests/actions/test_symlink_action.py
+++ b/astrality/tests/actions/test_symlink_action.py
@@ -5,6 +5,17 @@ from pathlib import Path
 from astrality.actions import SymlinkAction
 
 
+def test_null_object_pattern():
+    """Copy actions without options should do nothing."""
+    symlink_action = SymlinkAction(
+        options={},
+        directory=Path('/'),
+        replacer=lambda x: x,
+        context_store={},
+    )
+    symlink_action.execute()
+
+
 def test_symlink_action_using_all_parameters(tmpdir):
     """All three parameters should be respected."""
     temp_dir = Path(tmpdir) / 'content'

--- a/astrality/tests/actions/test_symlink_action.py
+++ b/astrality/tests/actions/test_symlink_action.py
@@ -125,3 +125,6 @@ def test_symlinking_file_to_directory(tmpdir):
 
     assert (target / 'file1').is_symlink()
     assert (target / 'file1').resolve() == file1
+    assert symlink_action.symlinked_files == {
+        file1: {target / 'file1'},
+    }

--- a/astrality/tests/actions/test_symlink_action.py
+++ b/astrality/tests/actions/test_symlink_action.py
@@ -1,0 +1,116 @@
+"""Tests for astrality.actions.SymlinkAction."""
+
+from pathlib import Path
+
+from astrality.actions import SymlinkAction
+
+
+def test_symlink_action_using_all_parameters(tmpdir):
+    """All three parameters should be respected."""
+    temp_dir = Path(tmpdir) / 'content'
+    temp_dir.mkdir()
+
+    target = Path(tmpdir) / 'target'
+    target.mkdir()
+
+    file1 = temp_dir / 'file1'
+    file1.touch()
+
+    file2 = temp_dir / 'file2'
+    file2.touch()
+
+    recursive_dir = temp_dir / 'recursive'
+    recursive_dir.mkdir()
+
+    file3 = temp_dir / 'recursive' / 'file3'
+    file3.touch()
+
+    symlink_options = {
+        'content': str(temp_dir),
+        'target': str(target),
+        'include': r'file(\d)',
+    }
+    symlink_action = SymlinkAction(
+        options=symlink_options,
+        directory=temp_dir,
+        replacer=lambda x: x,
+        context_store={},
+    )
+    symlink_action.execute()
+
+    assert (target / '1').is_symlink()
+    assert (target / '2').is_symlink()
+    assert (target / 'recursive' / '3').is_symlink()
+
+    assert (target / '1').resolve() == file1
+    assert (target / '2').resolve() == file2
+    assert (target / 'recursive' / '3').resolve() == file3
+
+
+def test_symlinking_without_renaming(tmpdir):
+    """When include is not given, keep symlink name."""
+    temp_dir = Path(tmpdir) / 'content'
+    temp_dir.mkdir()
+
+    target = Path(tmpdir) / 'target'
+    target.mkdir()
+
+    file1 = temp_dir / 'file1'
+    file1.touch()
+
+    file2 = temp_dir / 'file2'
+    file2.touch()
+
+    recursive_dir = temp_dir / 'recursive'
+    recursive_dir.mkdir()
+
+    file3 = temp_dir / 'recursive' / 'file3'
+    file3.touch()
+
+    symlink_options = {
+        'content': str(temp_dir),
+        'target': str(target),
+    }
+    symlink_action = SymlinkAction(
+        options=symlink_options,
+        directory=temp_dir,
+        replacer=lambda x: x,
+        context_store={},
+    )
+    symlink_action.execute()
+
+    assert (target / 'file1').is_symlink()
+    assert (target / 'file2').is_symlink()
+    assert (target / 'recursive' / 'file3').is_symlink()
+
+    assert (target / 'file1').resolve() == file1
+    assert (target / 'file2').resolve() == file2
+    assert (target / 'recursive' / 'file3').resolve() == file3
+
+
+def test_symlinking_file_to_directory(tmpdir):
+    """If symlinking from directory to file, place file in directory."""
+    temp_dir = Path(tmpdir) / 'content'
+    temp_dir.mkdir()
+
+    target = Path(tmpdir) / 'target'
+    target.mkdir()
+
+    file1 = temp_dir / 'file1'
+    file1.touch()
+
+    symlink_options = {
+        'content': str(file1),
+        'target': str(target),
+        'include': r'file1',
+    }
+    symlink_action = SymlinkAction(
+        options=symlink_options,
+        directory=temp_dir,
+        replacer=lambda x: x,
+        context_store={},
+    )
+    symlink_action.execute()
+
+    assert (target / 'file1').is_symlink()
+    assert (target / 'file1').resolve() == file1

--- a/astrality/tests/conftest.py
+++ b/astrality/tests/conftest.py
@@ -78,7 +78,71 @@ def context_directory(test_config_directory):
     """Return path to directory containing several context files."""
     return test_config_directory / 'context'
 
+
 @pytest.fixture
 def template_directory(test_config_directory):
     """Return path to directory containing several templates"""
     return test_config_directory / 'templates'
+
+
+@pytest.yield_fixture
+def module_factory(test_config_directory):
+    def _module_factory(
+        config,
+        module_directory=test_config_directory / 'test_modules' /
+        'using_all_actions',
+        replacer=lambda x: x,
+        context_store={},
+    ) -> Module:
+        if not 'module/' in list(config.keys())[0]:
+            config = {'module/test': config}
+
+        return Module(
+            module_config=config,
+            module_directory=module_directory,
+            replacer=replacer,
+            context_store=context_store,
+        )
+
+    yield _module_factory
+
+
+@pytest.fixture
+def create_temp_files(tmpdir):
+    """Return temp file factory function."""
+    temp_dir = Path(tmpdir)
+
+    def _create_temp_files(number):
+        """Create `number` tempfiles in seperate directories and yield paths."""
+        for _number in range(number):
+            temp_file = temp_dir / str(_number) / f'file{_number}.temp'
+            temp_file.parent.mkdir(parents=True)
+            temp_file.touch()
+            yield temp_file
+
+    return _create_temp_files
+
+
+@pytest.fixture
+def action_block_factory(test_config_directory):
+    """Return action block factory function for testing."""
+
+    def _action_block_factory(
+        symlink={},
+        directory=test_config_directory,
+        replacer=lambda x: x,
+        context_store={},
+    ):
+        """Return module with given parameters."""
+        config = {
+            'symlink': symlink,
+        }
+
+        return ActionBlock(
+            action_block=config,
+            directory=directory,
+            replacer=replacer,
+            context_store=context_store,
+        )
+
+    return _action_block_factory

--- a/astrality/tests/conftest.py
+++ b/astrality/tests/conftest.py
@@ -6,10 +6,12 @@ from pathlib import Path
 
 import pytest
 
+from astrality.actions import ActionBlock
 from astrality.config import (
     ASTRALITY_DEFAULT_GLOBAL_SETTINGS,
     user_configuration,
 )
+from astrality.module import Module
 from astrality.utils import generate_expanded_env_dict
 
 
@@ -94,7 +96,7 @@ def module_factory(test_config_directory):
         replacer=lambda x: x,
         context_store={},
     ) -> Module:
-        if not 'module/' in list(config.keys())[0]:
+        if 'module/' not in list(config.keys())[0]:
             config = {'module/test': config}
 
         return Module(
@@ -128,6 +130,10 @@ def action_block_factory(test_config_directory):
     """Return action block factory function for testing."""
 
     def _action_block_factory(
+        compile={},
+        copy={},
+        run={},
+        stow={},
         symlink={},
         directory=test_config_directory,
         replacer=lambda x: x,
@@ -135,6 +141,10 @@ def action_block_factory(test_config_directory):
     ):
         """Return module with given parameters."""
         config = {
+            'compile': compile,
+            'copy': copy,
+            'run': run,
+            'stow': stow,
             'symlink': symlink,
         }
 

--- a/astrality/tests/conftest.py
+++ b/astrality/tests/conftest.py
@@ -87,26 +87,27 @@ def template_directory(test_config_directory):
     return test_config_directory / 'templates'
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def module_factory(test_config_directory):
     def _module_factory(
-        config,
+        on_startup=None,
         module_directory=test_config_directory / 'test_modules' /
         'using_all_actions',
         replacer=lambda x: x,
         context_store={},
     ) -> Module:
-        if 'module/' not in list(config.keys())[0]:
-            config = {'module/test': config}
-
-        return Module(
-            module_config=config,
+        module = Module(
+            module_config={'module/test': {}},
             module_directory=module_directory,
             replacer=replacer,
             context_store=context_store,
         )
+        if on_startup:
+            module.action_blocks['on_startup'] = on_startup
 
-    yield _module_factory
+        return module
+
+    return _module_factory
 
 
 @pytest.fixture

--- a/astrality/tests/conftest.py
+++ b/astrality/tests/conftest.py
@@ -93,6 +93,7 @@ def module_factory(test_config_directory):
     def _module_factory(
         on_startup=None,
         on_modified=None,
+        on_exit=None,
         path=None,
         module_directory=test_config_directory / 'test_modules' /
         'using_all_actions',
@@ -108,6 +109,9 @@ def module_factory(test_config_directory):
         )
         if on_startup:
             module.action_blocks['on_startup'] = on_startup
+
+        if on_exit:
+            module.action_blocks['on_exit'] = on_exit
 
         if on_modified:
             module.action_blocks['on_modified'][path] = on_modified

--- a/astrality/tests/conftest.py
+++ b/astrality/tests/conftest.py
@@ -11,7 +11,7 @@ from astrality.config import (
     ASTRALITY_DEFAULT_GLOBAL_SETTINGS,
     user_configuration,
 )
-from astrality.module import Module
+from astrality.module import Module, ModuleManager
 from astrality.utils import generate_expanded_env_dict
 
 
@@ -119,6 +119,15 @@ def module_factory(test_config_directory):
         return module
 
     return _module_factory
+
+
+@pytest.fixture
+def module_manager(
+    default_global_options,
+    _runtime,
+):
+    default_global_options.update(_runtime)
+    return ModuleManager(default_global_options)
 
 
 @pytest.fixture

--- a/astrality/tests/conftest.py
+++ b/astrality/tests/conftest.py
@@ -89,13 +89,17 @@ def template_directory(test_config_directory):
 
 @pytest.fixture
 def module_factory(test_config_directory):
+    """Return Module factory for testing."""
     def _module_factory(
         on_startup=None,
+        on_modified=None,
+        path=None,
         module_directory=test_config_directory / 'test_modules' /
         'using_all_actions',
         replacer=lambda x: x,
         context_store={},
     ) -> Module:
+        """Return module with specified action blocks and config."""
         module = Module(
             module_config={'module/test': {}},
             module_directory=module_directory,
@@ -104,6 +108,9 @@ def module_factory(test_config_directory):
         )
         if on_startup:
             module.action_blocks['on_startup'] = on_startup
+
+        if on_modified:
+            module.action_blocks['on_modified'][path] = on_modified
 
         return module
 

--- a/astrality/tests/module/module_manager/test_module_manager_copying.py
+++ b/astrality/tests/module/module_manager/test_module_manager_copying.py
@@ -1,0 +1,29 @@
+"""Tests for copying in ModuleManager."""
+
+from pathlib import Path
+
+
+def test_copying_in_on_modified_block(
+    action_block_factory,
+    create_temp_files,
+    module_factory,
+    module_manager,
+):
+    """Module should copy properly."""
+    file1, file2, file3, file4 = create_temp_files(4)
+    file2.write_text('original')
+    file4.write_text('some other content')
+
+    action_block = action_block_factory(
+        copy=[
+            {'content': str(file1), 'target': str(file2)},
+            {'content': str(file3), 'target': str(file4)},
+        ],
+    )
+    module = module_factory(on_modified=action_block, path=Path('/a/b/c'))
+    module_manager.modules = {'test': module}
+    module_manager.on_modified(Path('/a/b/c'))
+
+    # Check if content has been copied
+    assert file2.read_text() == file1.read_text()
+    assert file4.read_text() == file3.read_text()

--- a/astrality/tests/module/module_manager/test_module_manager_stowing.py
+++ b/astrality/tests/module/module_manager/test_module_manager_stowing.py
@@ -1,0 +1,36 @@
+"""Tests for ModuleManager stow action."""
+
+from pathlib import Path
+
+
+def test_stowing(
+    action_block_factory,
+    create_temp_files,
+    module_factory,
+    module_manager,
+):
+    """ModuleManager should stow properly."""
+    template, target = create_temp_files(2)
+    template.write_text('{{ env.EXAMPLE_ENV_VARIABLE }}')
+    symlink_target = template.parent / 'symlink_me'
+    symlink_target.touch()
+
+    action_block = action_block_factory(
+        stow={
+            'content': str(template.parent),
+            'target': str(target.parent),
+            'templates': r'file(0).temp',
+            'non_templates': 'symlink',
+        },
+    )
+    module = module_factory(
+        on_exit=action_block,
+    )
+    module_manager.modules = {'test': module}
+    module_manager.exit()
+
+    # Check if template has been compiled
+    assert Path(target.parent / '0').read_text() == 'test_value'
+
+    # Check if non_template has been symlinked
+    assert (template.parent / 'symlink_me').resolve() == symlink_target

--- a/astrality/tests/module/module_manager/test_module_manager_symlinking.py
+++ b/astrality/tests/module/module_manager/test_module_manager_symlinking.py
@@ -1,0 +1,32 @@
+"""Tests for symlinking in ModuleManager."""
+
+from pathlib import Path
+
+
+def test_symlinking_in_on_startup_block(
+    action_block_factory,
+    module_factory,
+    module_manager,
+    create_temp_files,
+):
+    """ModuleManager should symlink properly."""
+    file1, file2, file3, file4 = create_temp_files(4)
+    file2.write_text('original')
+
+    action_block = action_block_factory(
+        symlink=[
+            {'content': str(file1), 'target': str(file2)},
+            {'content': str(file3), 'target': str(file4)},
+        ],
+    )
+    module = module_factory(on_startup=action_block)
+    module_manager.modules = {'test': module}
+    module_manager.finish_tasks()
+
+    assert file2.is_symlink()
+    assert file2.resolve() == file1
+    assert file4.is_symlink()
+    assert file4.resolve() == file3
+
+    # Existing files should be backed up
+    assert Path(str(file2) + '.bak').read_text() == 'original'

--- a/astrality/tests/module/test_copying.py
+++ b/astrality/tests/module/test_copying.py
@@ -1,0 +1,27 @@
+"""Tests for copy Module method."""
+
+from pathlib import Path
+
+
+def test_copying_in_on_modified_block(
+    action_block_factory,
+    create_temp_files,
+    module_factory,
+):
+    """Module should copy properly."""
+    file1, file2, file3, file4 = create_temp_files(4)
+    file2.write_text('original')
+    file4.write_text('some other content')
+
+    action_block = action_block_factory(
+        copy=[
+            {'content': str(file1), 'target': str(file2)},
+            {'content': str(file3), 'target': str(file4)},
+        ],
+    )
+    module = module_factory(on_modified=action_block, path=Path('/a/b/c'))
+    module.copy(block_name='on_modified', path=Path('/a/b/c'))
+
+    # Check if content has been copied
+    assert file2.read_text() == file1.read_text()
+    assert file4.read_text() == file3.read_text()

--- a/astrality/tests/module/test_exit.py
+++ b/astrality/tests/module/test_exit.py
@@ -27,7 +27,7 @@ def test_that_all_exit_actions_are_correctly_performed(
                     'from_path': 'context/mercedes.yml',
                 },
                 'compile': {
-                    'source': 'templates/a_car.template',
+                    'content': 'templates/a_car.template',
                     'target': str(test_target),
                 },
             },
@@ -36,7 +36,7 @@ def test_that_all_exit_actions_are_correctly_performed(
                     'from_path': 'context/tesla.yml',
                 },
                 'compile': {
-                    'source': 'templates/a_car.template',
+                    'content': 'templates/a_car.template',
                     'target': str(test_target),
                 },
             },

--- a/astrality/tests/module/test_module.py
+++ b/astrality/tests/module/test_module.py
@@ -1,6 +1,7 @@
+"""Tests for Module class."""
+
 import logging
 import os
-import shutil
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -9,7 +10,6 @@ from freezegun import freeze_time
 import pytest
 
 from astrality import event_listener
-from astrality.config import dict_from_config_file
 from astrality.module import Module, ModuleManager
 from astrality.resolver import Resolver
 from astrality.tests.utils import RegexCompare
@@ -26,7 +26,7 @@ def valid_module_section():
                 'run': [{'shell': 'echo {event}'}],
                 'compile': [
                     {
-                        'source': '../templates/test_template.conf',
+                        'content': '../templates/test_template.conf',
                         'target': '/tmp/compiled_result',
                     },
                 ],
@@ -335,7 +335,7 @@ class TestModuleClass:
             'module/test_module': {
                 'on_startup': {
                     'compile': [
-                        {'source': '/not/existing'},
+                        {'content': '/not/existing'},
                     ],
                 },
             },
@@ -509,7 +509,7 @@ def config_with_modules(default_global_options):
             },
             'templates': {
                 'template_name': {
-                    'source': 'astrality/tests/templates/test_template.conf',
+                    'content': 'astrality/tests/templates/test_template.conf',
                     'target': '/tmp/compiled_result',
                 }
             },
@@ -706,7 +706,7 @@ def test_that_shell_filter_is_run_from_config_directory(
             'on_startup': {
                 'compile': [
                     {
-                        'source': str(shell_filter_template),
+                        'content': str(shell_filter_template),
                         'target': str(shell_filter_template_target),
                     }
                 ],
@@ -778,12 +778,6 @@ def test_that_only_startup_event_block_is_run_on_startup(
     assert test_file1.is_file()
     assert not test_file2.is_file()
 
-    friday = datetime(
-        year=2018,
-        month=2,
-        day=16,
-        hour=12,
-    )
 
 def test_trigger_event_module_action(
     test_config_directory,
@@ -815,7 +809,7 @@ def test_trigger_event_module_action(
                 'templateA': {
                     'run': [{'shell': 'echo modified.templateA'}],
                     'compile': [
-                        {'source': 'templateA'}
+                        {'content': 'templateA'}
                     ],
                 },
             },

--- a/astrality/tests/module/test_module_filewatching.py
+++ b/astrality/tests/module/test_module_filewatching.py
@@ -30,11 +30,11 @@ def modules_config(
                 str(empty_template): {
                     'compile': [
                         {
-                            'source' : str(empty_template),
+                            'content' : str(empty_template),
                             'target': str(empty_template_target),
                         },
                         {
-                            'source': str(secondary_template),
+                            'content': str(secondary_template),
                             'target': str(secondary_template_target),
                         },
                     ],
@@ -255,7 +255,7 @@ def test_all_three_actions_in_on_modified_block(
                     'from_path': str(mercedes_context),
                 },
                 'compile': {
-                    'source': str(car_template),
+                    'content': str(car_template),
                     'target': str(file1),
                 },
             },
@@ -265,7 +265,7 @@ def test_all_three_actions_in_on_modified_block(
                         'from_path': str(tesla_context),
                     },
                     'compile': {
-                        'source': str(car_template),
+                        'content': str(car_template),
                         'target': str(file1),
                     },
                     'run': {'shell': 'touch ' + str(file3)},
@@ -314,7 +314,7 @@ def test_recompile_templates_when_modified(
         'module/module_name': {
             'on_startup': {
                 'compile': {
-                    'source': str(template),
+                    'content': str(template),
                     'target': str(target),
                 },
             },
@@ -367,7 +367,7 @@ def test_recompile_templates_when_modified_overridden(
         'module/module_name': {
             'on_startup': {
                 'compile': {
-                    'source': str(template),
+                    'content': str(template),
                     'target': str(target),
                 },
             },

--- a/astrality/tests/module/test_module_filewatching.py
+++ b/astrality/tests/module/test_module_filewatching.py
@@ -326,7 +326,7 @@ def test_recompile_templates_when_modified(
     application_config.update(default_global_options)
     application_config.update(_runtime)
     application_config['config/modules'] = {
-        'recompile_modified_templates': True,
+        'reprocess_modified_files': True,
     }
 
     module_manager = ModuleManager(application_config)
@@ -358,7 +358,7 @@ def test_recompile_templates_when_modified_overridden(
 ):
     """
     If a file is watched in a on_modified block, it should override the
-    recompile_modified_templates option.
+    reprocess_modified_files option.
     """
     template, target, touch_target = three_watchable_files
     template.touch()
@@ -384,7 +384,7 @@ def test_recompile_templates_when_modified_overridden(
     application_config.update(default_global_options)
     application_config.update(_runtime)
     application_config['config/modules'] = {
-        'recompile_modified_templates': True,
+        'reprocess_modified_files': True,
     }
 
     module_manager = ModuleManager(application_config)

--- a/astrality/tests/module/test_permissions.py
+++ b/astrality/tests/module/test_permissions.py
@@ -4,6 +4,7 @@ import pytest
 
 from astrality.module import ModuleManager
 
+
 @pytest.mark.parametrize("specified_permission,expected_permission", [
         ("777", 0o777),
         ("100", 0o100),
@@ -23,7 +24,7 @@ def test_compiling_template_with_specific_permissions(
         'module/test': {
             'on_startup': {
                 'compile': {
-                    'source': str(template),
+                    'content': str(template),
                     'target': str(target),
                     'permissions': specified_permission,
                 },

--- a/astrality/tests/module/test_stowing.py
+++ b/astrality/tests/module/test_stowing.py
@@ -1,0 +1,34 @@
+"""Tests for Module stow action."""
+
+from pathlib import Path
+
+
+def test_stowing(
+    action_block_factory,
+    create_temp_files,
+    module_factory,
+):
+    """Module should stow properly."""
+    template, target = create_temp_files(2)
+    template.write_text('{{ env.EXAMPLE_ENV_VARIABLE }}')
+    symlink_target = template.parent / 'symlink_me'
+    symlink_target.touch()
+
+    action_block = action_block_factory(
+        stow={
+            'content': str(template.parent),
+            'target': str(target.parent),
+            'templates': r'file(0).temp',
+            'non_templates': 'symlink',
+        },
+    )
+    module = module_factory(
+        on_exit=action_block,
+    )
+    module.stow(block_name='on_exit')
+
+    # Check if template has been compiled
+    assert Path(target.parent / '0').read_text() == 'test_value'
+
+    # Check if non_template has been symlinked
+    assert (template.parent / 'symlink_me').resolve() == symlink_target

--- a/astrality/tests/module/test_string_interpolations.py
+++ b/astrality/tests/module/test_string_interpolations.py
@@ -31,7 +31,7 @@ def test_use_of_string_interpolations_of_module(
         'module/A': {
             'on_startup': {
                 'compile': [
-                    {'source': str(a_template)}
+                    {'content': str(a_template)}
                 ],
             },
         },
@@ -40,7 +40,7 @@ def test_use_of_string_interpolations_of_module(
                 str(b_on_modified): {
                     'compile': [
                         {
-                            'source': str(b_template),
+                            'content': str(b_template),
                             'target': str(b_target),
                         },
                     ],
@@ -50,7 +50,7 @@ def test_use_of_string_interpolations_of_module(
         'module/C': {
             'on_exit': {
                 'compile': {
-                        'source': str(c_template),
+                        'content': str(c_template),
                         'target': str(c_target),
                 },
             },

--- a/astrality/tests/module/test_symlinking.py
+++ b/astrality/tests/module/test_symlinking.py
@@ -1,0 +1,30 @@
+"""Tests for symlink actions in Module object."""
+
+from pathlib import Path
+
+
+def test_symlinking_in_on_startup_block(
+    action_block_factory,
+    module_factory,
+    create_temp_files,
+):
+    """Action blocks should symlink properly."""
+    file1, file2, file3, file4 = create_temp_files(4)
+    file2.write_text('original')
+
+    action_block = action_block_factory(
+        symlink=[
+            {'content': str(file1), 'target': str(file2)},
+            {'content': str(file3), 'target': str(file4)},
+        ],
+    )
+    module = module_factory(on_startup=action_block)
+    module.symlink(block_name='on_startup')
+
+    assert file2.is_symlink()
+    assert file2.resolve() == file1
+    assert file4.is_symlink()
+    assert file4.resolve() == file3
+
+    # Existing files should be backed up
+    assert Path(str(file2) + '.bak').read_text() == 'original'

--- a/astrality/tests/test_config/astrality1.yml
+++ b/astrality/tests/test_config/astrality1.yml
@@ -4,7 +4,7 @@ config/astrality:
 module/A:
     on_startup:
         compile:
-            - source: templates/no_context.template
+            - content: templates/no_context.template
               target: /tmp/astrality/target1
 
     on_exit:

--- a/astrality/tests/test_config/astrality2.yml
+++ b/astrality/tests/test_config/astrality2.yml
@@ -4,7 +4,7 @@ config/astrality:
 module/A:
     on_startup:
         compile:
-            - source: templates/no_context.template
+            - content: templates/no_context.template
               target: /tmp/astrality/target2
 
     on_exit:

--- a/astrality/tests/test_config/test_modules/using_all_actions/config.yml
+++ b/astrality/tests/test_config/test_modules/using_all_actions/config.yml
@@ -3,7 +3,7 @@ module/vietnam:
         import_context:
             from_path: south_context.yml
         compile:
-            source: module.template
+            content: module.template
             target: compiled.tmp
         run:
             - shell: touch touched.tmp
@@ -13,7 +13,7 @@ module/vietnam:
             import_context:
                 from_path: north_context.yml
             compile:
-                source: module.template
+                content: module.template
                 target: compiled.tmp
             run:
                 - shell: touch watch_touched.tmp

--- a/astrality/tests/test_test_utils.py
+++ b/astrality/tests/test_test_utils.py
@@ -1,3 +1,5 @@
+"""Tests for the test utils module."""
+
 from .utils import RegexCompare
 
 def test_use_of_regex_compare():

--- a/astrality/tests/utils.py
+++ b/astrality/tests/utils.py
@@ -2,6 +2,7 @@
 
 import re
 
+
 class RegexCompare:
     """
     Class for creating regex objects which can be compared with strings.

--- a/astrality/tests/utils/test_resolve_targets.py
+++ b/astrality/tests/utils/test_resolve_targets.py
@@ -1,0 +1,117 @@
+"""Tests for utils.resolve_targets."""
+
+from pathlib import Path
+
+from astrality.utils import resolve_targets
+
+
+def test_resolving_non_existent_file():
+    """When `content` does not exist, no targets should be returned."""
+    targets = resolve_targets(
+        content=Path('/does/not/exist'),
+        target=Path('/'),
+        include=r'.*',
+    )
+    assert targets == {}
+
+
+def test_resolving_target_of_content_file():
+    """When `content` is a file, the target root is used."""
+    targets = resolve_targets(
+        content=Path(__file__),
+        target=Path('/does/not/exist'),
+        include=r'.*',
+    )
+    assert targets == {Path(__file__): Path('/does/not/exist')}
+
+
+def test_resolving_target_file_to_directory():
+    """When content is a file, but target is a directory, keep filename."""
+    targets = resolve_targets(
+        content=Path(__file__),
+        target=Path('/tmp'),
+        include=r'.*',
+    )
+    assert targets == {Path(__file__): Path('/tmp/test_resolve_targets.py')}
+
+
+def test_resolving_content_directory(tmpdir):
+    """Directory hierarchy should be preserved at target."""
+    temp_dir = Path(tmpdir)
+
+    file1 = temp_dir / 'file1'
+    file1.touch()
+
+    file2 = temp_dir / 'file2'
+    file2.touch()
+
+    recursive_dir = temp_dir / 'recursive'
+    recursive_dir.mkdir()
+
+    file3 = temp_dir / 'recursive' / 'file3'
+    file3.touch()
+
+    targets = resolve_targets(
+        content=temp_dir,
+        target=Path('/a/b'),
+        include=r'.*',
+    )
+    assert targets == {
+        file1: Path('/a/b/file1'),
+        file2: Path('/a/b/file2'),
+        file3: Path('/a/b/recursive/file3'),
+    }
+
+
+def test_filtering_based_on_include(tmpdir):
+    """Only files that match the regex should be included."""
+    temp_dir = Path(tmpdir)
+
+    file1 = temp_dir / 'file1'
+    file1.touch()
+
+    file2 = temp_dir / 'file2'
+    file2.touch()
+
+    recursive_dir = temp_dir / 'recursive'
+    recursive_dir.mkdir()
+
+    file3 = temp_dir / 'recursive' / 'file3'
+    file3.touch()
+
+    targets = resolve_targets(
+        content=temp_dir,
+        target=Path('/a/b'),
+        include=r'.+3',
+    )
+    assert targets == {
+        file3: Path('/a/b/recursive/file3'),
+    }
+
+
+def test_renaming_based_on_include(tmpdir):
+    """Targets should be renameable based on the include capture group."""
+    temp_dir = Path(tmpdir)
+
+    file1 = temp_dir / 'file1'
+    file1.touch()
+
+    file2 = temp_dir / 'file2'
+    file2.touch()
+
+    recursive_dir = temp_dir / 'recursive'
+    recursive_dir.mkdir()
+
+    file3 = temp_dir / 'recursive' / 'file3'
+    file3.touch()
+
+    targets = resolve_targets(
+        content=temp_dir,
+        target=Path('/a/b'),
+        include=r'.+(\d)',
+    )
+    assert targets == {
+        file1: Path('/a/b/1'),
+        file2: Path('/a/b/2'),
+        file3: Path('/a/b/recursive/3'),
+    }

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -177,19 +177,40 @@ Demonstration of module action blocks:
 Actions
 =======
 
-Actions are tasks for Astrality to perform, and are placed within :ref:`action blocks <modules_action_blocks>` in order to specify *when* to perform them. There are four available ``action`` types:
+Actions are tasks for Astrality to perform, and are placed within :ref:`action
+blocks <modules_action_blocks>` in order to specify *when* to perform them.
+These are the available ``action`` types:
 
     :ref:`import_context <context_import_action>`:
-        Import a ``context`` section from a YAML formatted file. ``context`` variables are used as replacement values for placeholders in your :ref:`templates <templating>`. See :ref:`context <context>` for more information.
+        Import a ``context`` section from a YAML formatted file. ``context``
+        variables are used as replacement values for placeholders in your
+        :ref:`templates <templating>`. See :ref:`context <context>` for more
+        information.
 
     :ref:`compile <compile_action>`:
-        Compile a specific template to a target path.
+        Compile a specific template or template directory to a target path.
+
+    :ref:`copy <copy_action>`:
+        Copy a specific file or directory to a target path.
+
+    :ref:`symlink <symlink_action>`:
+        Create symbolic link(s) pointing to a specific file or directory.
+
+    :ref:`stow <stow_action>`:
+        Combination of ``compile`` + ``copy`` or ``compile`` + ``symlink``,
+        bisected based on filename pattern of files within a content directory.
 
     :ref:`run <run_action>`:
-        Execute a shell command, possibly referring to any compiled template and/or the last detected :ref:`event <event_listener_events>` defined by the :ref:`module event listener <event_listeners>`.
+        Execute a shell command, possibly referring to any compiled template
+        and/or the last detected :ref:`event <event_listener_events>` defined
+        by the :ref:`module event listener <event_listeners>`.
 
     :ref:`trigger <trigger_action>`:
-        Perform *all* actions specified within another :ref:`action block <modules_action_blocks>`. With other words, this action *appends* all the actions within another action block to the actions already specified in the action block. Useful for not having to repeat yourself when you want the same actions to be performed during different events.
+        Perform *all* actions specified within another :ref:`action block
+        <modules_action_blocks>`. With other words, this action *appends* all
+        the actions within another action block to the actions already
+        specified in the action block. Useful for not having to repeat yourself
+        when you want the same actions to be performed during different events.
 
 
 .. _context_import_action:
@@ -275,10 +296,10 @@ of a module.
 
 Each template compilation action has the following available attributes:
 
-    ``source:``
+    ``content:``
         Path to either a template file or template directory.
 
-        If ``source`` is a directory, Astrality will compile all templates
+        If ``content`` is a directory, Astrality will compile all templates
         recursively to the ``target`` directory, preserving the directory
         hierarchy.
 
@@ -287,21 +308,30 @@ Each template compilation action has the following available attributes:
 
         Path which specifies where to put the *compiled* template.
 
-        You can skip this option if you do not care where the compiled template is placed, and what it is named.
-        You can still use the compiled result by writing ``{template_path}`` in the rest of your module. This placeholder will be replaced with the absolute path of the compiled template. You can for instance refer to the file in :ref:`a shell command <run_action>`.
+        You can skip this option if you do not care where the compiled template
+        is placed, and what it is named. You can still use the compiled result
+        by writing ``{template_path}`` in the rest of your module. This
+        placeholder will be replaced with the absolute path of the compiled
+        template. You can for instance refer to the file in :ref:`a shell
+        command <run_action>`.
 
         .. warning::
-            When you do not provide Astrality with a ``target`` path for a template, Astrality will create a *temporary* file as the target for compilation. This file will be automatically deleted when you quit Astrality.
+            When you do not provide Astrality with a ``target`` path for
+            a template, Astrality will create a *temporary* file as the target
+            for compilation. This file will be automatically deleted when you
+            quit Astrality.
 
-    ``templates:`` *[Optional]*
+    .. _compile_action_include:
+
+    ``include`` *[Optional]*
         *Default:* ``'(.+)'``
 
-        Regular expression restricting which filenames that should be compiled
-        as templates.  Useful when ``source`` is a directory which contains
+        Regular expression defining which filenames that are considered to be
+        templates. Useful when ``content`` is a directory which contains
         non-template files. By default Astrality will try to compile all files.
 
         If you specify a capture group, astrality will use the captured string
-        as the target filename. For example, ``templates: '^template\.(.+)$'``
+        as the target filename. For example, ``templates: 'template\.(.+)'``
         will match the file "template.kitty.conf" and rename the target to
         "kitty.conf".
 
@@ -316,18 +346,30 @@ Each template compilation action has the following available attributes:
 
         What to do with files that do not match the ``templates`` regex.
 
+    .. _compile_action_permissions:
+
     ``permissions:`` *[Optional]*
-        *Default:* Same permissions as source file.
+        *Default:* Same permissions as the template file.
 
         The file mode (i.e. permission bits) assigned to the *compiled* template.
-        Given either as a string of octal permissions, such as ``'755'``, or as a string of symbolic permissions, such as ``'u+x'``. This option is passed to the linux shell command ``chmod``. Refer to ``chmod``'s manual for the full details on possible arguments.
+        Given either as a string of octal permissions, such as ``'755'``, or as
+        a string of symbolic permissions, such as ``'u+x'``. This option is
+        passed to the linux shell command ``chmod``. Refer to ``chmod``'s
+        manual for the full details on possible arguments.
 
         .. note::
-            The permissions specified in the ``permissions`` option are applied *on top* of the default permissions copied from the template file.
+            The permissions specified in the ``permissions`` option are applied
+            *on top* of the default permissions copied from the template file.
 
-            For example, if the template's permissions are ``rw-r--r-- (644)`` and the value of ``'ug+x'`` is supplied for the ``permissions`` option, the ``644`` permissions will first be copied to the resulting compiled file and then ``chmod ug+x`` will be applied on top of that to give a resulting permission on the file of ``rwxr-xr-- (754)``.
+            For example, if the template's permissions are ``rw-r--r-- (644)``
+            and the value of ``'ug+x'`` is supplied for the ``permissions``
+            option, the ``644`` permissions will first be copied to the
+            resulting compiled file and then ``chmod ug+x`` will be applied on
+            top of that to give a resulting permission on the file of
+            ``rwxr-xr-- (754)``.
 
-            If an invalid value is supplied for the ``permissions`` option, only the default permissions are copied to the compiled file.
+            If an invalid value is supplied for the ``permissions`` option,
+            only the default permissions are copied to the compiled file.
 
 
 Here is an example:
@@ -337,19 +379,165 @@ Here is an example:
     module/desktop:
         on_startup:
             compile:
-                - source: modules/scripts/executable.sh.template
+                - content: modules/scripts/executable.sh.template
                   target: ${XDG_CONFIG_HOME}/bin/executable.sh
                   permissions: 0o555
-                - source: modules/desktop/conky_module.template
+                - content: modules/desktop/conky_module.template
 
             run:
                 - shell: conky -c {modules/desktop/conky_module.template}
                 - shell: polybar bar
 
-Notice that the shell command ``conky -c {modules/desktop/conky_module.template}`` is replaced with something like ``conky -c /path/to/compiled/template.temp``.
+Notice that the shell command ``conky -c
+{modules/desktop/conky_module.template}`` is replaced with something like
+``conky -c /tmp/astrality/compiled.conky_module.template``.
 
 .. note::
-    All relative file paths are interpreted relative to the :ref:`config directory<config_directory>` of Astrality.
+    All relative file paths are interpreted relative to the :ref:`config
+    directory<config_directory>` of Astrality.
+
+
+.. _symlink_action:
+
+Symlink files
+-------------
+
+You can ``symlink`` a file or directory to a target destination. Directories
+will be recursively symlinked, leaving any non-conflicting files intact. The
+``symlink`` action have the following available parameters.
+
+    ``content:``
+        The target of the symlinking, with other words a path to a file or
+        directory with the actual file content.
+
+        If ``to`` is a directory, Astrality will create an identical
+        directory hierarchy at the ``from`` directory path and create
+        separate symlinks for each file in ``to``.
+
+    ``target:``
+        Where to place the symlink(s).
+
+        .. caution::
+            This is the *location* of the symlink, **not** where the symlink
+            *points to*.
+
+    ``include`` *[Optional]*
+        *Default:* ``'(.+)'``
+
+        Regular expression restricting which filenames that should be
+        symlinked. By default Astrality will try to symlink all files.
+
+        If you specify a capture group, astrality will use the captured string
+        as the symlink name. For example, ``include: 'symlink\.(.+)'`` will
+        match the file "symlink.wallpaper.jpeg" and rename the symlink to
+        "wallpaper.jpeg".
+
+
+.. _copy_action:
+
+Copy files
+----------
+
+You can ``copy`` a file or directory to a target destination. Directories will
+be recursively copied, leaving non-conflicting files intact. The ``copy``
+action have the following available parameters.
+
+    ``content:``
+        Where to copy *from*, with other words a path to a file or directory
+        with existing content to be copied.
+
+        If ``content`` is a directory, Astrality will create an identical
+        directory hierarchy at the ``to`` directory path and recursively
+        copy all files.
+
+    ``target:``
+        A path specifying where to copy *to*.
+        Any non-conflicting files at the target destination will be left alone.
+
+    ``include`` *[Optional]*
+        *Default:* ``'(.+)'``
+
+        Regular expression restricting which filenames that should be
+        copied. By default Astrality will try to copy all files.
+
+        If you specify a capture group, astrality will use the captured string
+        as the name for the copied file. For example, ``include: 'copy\.(.+)'``
+        will copy the file "copy.binary.blob" and rename the copy to
+        "binary.blob".
+
+    ``permissions:`` *[Optional]*
+        *Default:* Same permissions as the original file(s).
+
+        See :ref:`compilation permissions <compile_action_permissions>` for
+        more information.
+
+
+
+.. _stow_action:
+
+Stow a directory
+----------------
+
+Often you want to:
+
+#. Move all content from a directory in your dotfile repository to a specific
+   target directory, while...
+#. Compiling any template according to a consistent naming scheme, and...
+#. Symlink or copy the remaining files which are *not* templates.
+
+The ``stow`` action type allows you to do just that! Stow has the following
+available parameters:
+
+    ``content:``
+        Path to a directory of mixed content, i.e. both templates and
+        non-templates.
+
+    ``target:``
+        Path to directory where processed content should be placed.
+        Templates will be compiled to ``target``, and the remaining files will
+        be treated according to the ``non_templates`` parameter.
+
+    ``templates:`` *[Optional]*
+        *Default:* ``'template\.(.+)'``
+
+        Regular expression restricting which filenames that should be compiled
+        as templates. By default, Astrality will only compile files named
+        "template.*" and rename the compilation target to "*".
+
+        See the compile action :ref:`include parameter <compile_action_include>`
+        for more information.
+
+    ``non_templates:`` *[Optional]*
+        *Default:* ``'symlink'``
+
+        *Accepts:* ``symlink``, ``copy``, ``ignore``
+
+        What to do with files that do not match the ``templates`` regex.
+
+    ``permissions:`` *[Optional]*
+        *Default:* Same permissions as the original file(s).
+
+        See :ref:`compilation permissions <compile_action_permissions>` for
+        more information.
+
+
+Here is an example module which compiles all files matching the glob
+``$XDG_CONFIG_HOME/**/*.t``, and places the *compiled* template besides the
+template, but *without* the file extension ".t". It leaves all other files
+alone:
+
+.. code-block:: yaml
+
+    # $ASTRALITY_CONFIG_HOME/astrality.yml
+
+    module/dotfiles:
+        on_startup:
+            stow:
+                content: $XDG_CONFIG_HOME
+                target: $XDG_CONFIG_HOME
+                templates: '(.+)\.t'
+                non_templates: ignore
+
 
 
 .. _run_action:
@@ -442,7 +630,7 @@ An example of a module using ``trigger`` actions:
         on_modified:
             templates/A.template:
                 compile:
-                    source: templates/A.template
+                    content: templates/A.template
 
                 run: shell_command_dependent_on_templateA
 
@@ -461,7 +649,7 @@ This is equivalent to writing the following module:
                   to_section: a_stuff
 
             compile:
-                source: templates/templateA
+                content: templates/templateA
 
             run:
                 - shell: startup_command
@@ -474,7 +662,7 @@ This is equivalent to writing the following module:
                 to_section: a_stuff
 
             compile:
-                source: templateA
+                content: templateA
 
             run:
                 - shell: shell_command_dependent_on_templateA
@@ -482,7 +670,7 @@ This is equivalent to writing the following module:
         on_modified:
             templates/templateA:
                 compile:
-                    source: templates/templateA
+                    content: templates/templateA
 
                 run:
                     - shell: shell_command_dependent_on_templateA
@@ -502,14 +690,19 @@ The execution order of module actions
 The order of action execution is as follows:
 
     #. :ref:`context_import <context_import_action>` for each module.
+    #. :ref:`symlink <symlink_action>` for each module.
+    #. :ref:`copy <copy_action>` for each module.
     #. :ref:`compile <compile_action>` for each module.
+    #. :ref:`stow <stow_action>` for each module.
     #. :ref:`run <run_action>` for each module.
 
-Modules are iterated over from top to bottom such that they appear in ``astrality.yml``.
-This ensures the following invariants:
+Modules are iterated over from top to bottom such that they appear in
+``astrality.yml``. This ensures the following invariants:
 
-    * When you compile templates, all ``context`` imports have been performed, and are available for placeholder substitution.
-    * When you run shell commands, all templates have been compiled, and are available for reference.
+    * When you compile templates, all ``context`` imports have been performed,
+      and are available for placeholder substitution.
+    * When you run shell commands, all (non-)templates have been
+      compiled/copied/symlinked, and are available for reference.
 
 
 .. _modules_global_config:

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -740,14 +740,15 @@ Global configuration options for all your modules are specified in ``astrality.y
 
     If enabled, Astrality will watch for file modifications in
     ``$ASTRALITY_CONFIG_HOME``.
-    All ``compile_action`` items that contain ``template`` paths that have been
-    modified will be compiled again.
+    All files that have been compiled or copied to a destination will be
+    recompiled or recopied if they are modified.
 
     .. hint::
         You can have more fine-grained control over exactly *what* happens when
-        a file is modified by using the ``on_modified`` :ref:`module event <modules_action_blocks>`.
-        This way you can run shell commands, import context values, and compile
-        arbitrary templates when specific files are modified on disk.
+        a file is modified by using the ``on_modified`` :ref:`module event
+        <modules_action_blocks>`. This way you can run shell commands, import
+        context values, and compile arbitrary templates when specific files are
+        modified on disk.
 
     .. caution::
         At the moment, Astrality only watches for file changes recursively within

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -732,7 +732,7 @@ Global configuration options for all your modules are specified in ``astrality.y
 
     *Useful when you are dependent on shell commands running sequantially.*
 
-``recompile_modified_templates:``
+``reprocess_modified_files:``
     *Default:* ``false``
 
     If enabled, Astrality will watch for file modifications in

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -425,6 +425,9 @@ will be recursively symlinked, leaving any non-conflicting files intact. The
         match the file "symlink.wallpaper.jpeg" and rename the symlink to
         "wallpaper.jpeg".
 
+.. note::
+    If you astrality encounters an existing **file** where it is supposed to
+    place a symbolic link, it will rename the existing file to "filename.bak".
 
 .. _copy_action:
 

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -275,14 +275,14 @@ of a module.
 
 Each template compilation action has the following available attributes:
 
-    ``source``:
+    ``source:``
         Path to either a template file or template directory.
 
         If ``source`` is a directory, Astrality will compile all templates
         recursively to the ``target`` directory, preserving the directory
         hierarchy.
 
-    ``target``: *[Optional]*
+    ``target:`` *[Optional]*
         *Default:* Temporary file created by Astrality.
 
         Path which specifies where to put the *compiled* template.
@@ -293,7 +293,30 @@ Each template compilation action has the following available attributes:
         .. warning::
             When you do not provide Astrality with a ``target`` path for a template, Astrality will create a *temporary* file as the target for compilation. This file will be automatically deleted when you quit Astrality.
 
-    ``permissions``: *[Optional]*
+    ``templates:`` *[Optional]*
+        *Default:* ``'(.+)'``
+
+        Regular expression restricting which filenames that should be compiled
+        as templates.  Useful when ``source`` is a directory which contains
+        non-template files. By default Astrality will try to compile all files.
+
+        If you specify a capture group, astrality will use the captured string
+        as the target filename. For example, ``templates: '^template\.(.+)$'``
+        will match the file "template.kitty.conf" and rename the target to
+        "kitty.conf".
+
+        .. hint::
+            You can test your regex `here <https://regex101.com/r/myMbmT/1>`_.
+            Astrality uses the capture group with the greatest index.
+
+    ``non_templates:`` *[Optional]*
+        *Default:* ``'symlink'``
+
+        *Accepts:* ``symlink``, ``copy``, ``ignore``
+
+        What to do with files that do not match the ``templates`` regex.
+
+    ``permissions:`` *[Optional]*
         *Default:* Same permissions as source file.
 
         The file mode (i.e. permission bits) assigned to the *compiled* template.

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -339,13 +339,6 @@ Each template compilation action has the following available attributes:
             You can test your regex `here <https://regex101.com/r/myMbmT/1>`_.
             Astrality uses the capture group with the greatest index.
 
-    ``non_templates:`` *[Optional]*
-        *Default:* ``'symlink'``
-
-        *Accepts:* ``symlink``, ``copy``, ``ignore``
-
-        What to do with files that do not match the ``templates`` regex.
-
     .. _compile_action_permissions:
 
     ``permissions:`` *[Optional]*

--- a/docs/templating.rst
+++ b/docs/templating.rst
@@ -280,7 +280,7 @@ which will compile the template on Astrality startup:
     module/some_name:
         on_startup:
             compile:
-                - source: modules/test/template
+                - content: modules/test/template
                   target: /tmp/config.ini
 
 Now we can compile the template by starting Astrality:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -47,14 +47,14 @@ Let us go through the module configuration step-by-step:
 We can now compile all such templates within *$XDG_CONFIG_HOME* by running
 ``astrality`` from the shell. But we would like to *automatically* recompile
 templates when we modify them or create new ones. You can achieve this by
-enabling ``recompile_modified_templates``:
+enabling ``reprocess_modified_files``:
 
 .. code-block:: yaml
 
     # $ASTRALITY_CONFIG_HOME/astrality.yml
 
     config/modules:
-        recompile_modified_templates: true
+        reprocess_modified_files: true
 
 Astrality will automatically recompile any modified templates as long as it
 runs as a background process.
@@ -82,7 +82,7 @@ accordingly:
     # ~/.dotfiles/astrality.yml
 
     config/modules:
-        recompile_modified_templates: true
+        reprocess_modified_files: true
 
     module/dotfiles:
         on_startup:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -19,7 +19,8 @@ Let us start by managing the files located in ``$XDG_CONFIG_HOME``, where most
 configuration files reside. The default value of this environment variable is
 "~/.config". We will create an Astrality module which automatically detects
 files named "template.whatever", and compile it to "whatever". This way you can
-easily add new templates without having to add new configuration.
+easily write new templates without having to add new configuration in order to
+compile them.
 
 .. code-block:: yaml
 
@@ -28,21 +29,20 @@ easily add new templates without having to add new configuration.
     module/dotfiles:
         on_startup:
             compile:
-                source: $XDG_CONFIG_HOME
+                content: $XDG_CONFIG_HOME
                 target: $XDG_CONFIG_HOME
-                templates: 'template\.(.+)'
-                non_templates: ignore
+                include: 'template\.(.+)'
 
 Let us go through the module configuration step-by-step:
 
-- We set both the source and target to be ``$XDG_CONFIG_HOME``, compiling any
+- We use the ``compile`` action type, as we are only interested in compiling
+  templates at the moment.
+- We set both the content and target to be ``$XDG_CONFIG_HOME``, compiling any
   template to the same directory as the template.
 - We only want to compile template filenames which matches the regular
   expression ``template\.(.+)``.
 - The regex capture group in ``template\.(.+)`` specifies that everything
   appearing after "template." should be used as the *compiled* target filename.
-- ``non_templates: ignore`` instructs Astrality to leave any non-templates
-  alone.
 
 We can now compile all such templates within *$XDG_CONFIG_HOME* by running
 ``astrality`` from the shell. But we would like to *automatically* recompile
@@ -67,12 +67,14 @@ locations, ``$HOME``, ``$XDG_CONFIG_HOME``, ``$/etc`` on so on. You can do all
 of this with Astrality.
 
 
-For demonstration purposes, let us assume that the contents of
+For demonstration purposes, let us assume that the templates within
 "~/.dotfiles/home" should be compiled to "~", and "~/.dotfiles/etc" to "/etc",
-while non-templates should be symlinked instead.
+while non-templates should be symlinked instead. This combination of
+:ref:`symlink <symlink_action>` and :ref:`compile <compile_action>` actions can
+be done with the :ref:`stow <stow_action>` action.
 
-Move ``astrality.yml`` to the root of your dotfiles repository, set ``export
-ASTRALITY_CONFIG_HOME=~/.dotfiles``, and modify the dotfiles module
+Move ``astrality.yml`` to the root of your dotfiles repository. Set ``export
+ASTRALITY_CONFIG_HOME=~/.dotfiles``. Finally, modify the dotfiles module
 accordingly:
 
 .. code-block:: yaml
@@ -84,21 +86,24 @@ accordingly:
 
     module/dotfiles:
         on_startup:
-            compile:
-                - source: home
+            stow:
+                - content: home
                   target: ~
                   templates: 'template\.(.+)'
                   non_templates: symlink
 
-                - source: etc
+                - content: etc
                   target: /etc
                   templates: 'template\.(.+)'
                   non_templates: symlink
 
-Symlink is actually the default option, so we could have skipped specifying it
-altogether. You can also specify ``copy``. You can now start to write all your
-configuration files as templates instead, using placeholders for secret API
-keys or configuration values that change between machines, and much much more.
+``templates: 'template\.(.+)'`` and ``non_templates: symlink`` are actually the
+default options for the stow action, so we could have skipped specifying them
+altogether. Alternatively, you can specify ``non_templates: copy``.
+
+You can now start to write all your configuration files as templates instead,
+using placeholders for secret API keys or configuration values that change
+between machines, and much much more.
 
 .. _examples_weekday_wallpaper:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,13 +23,12 @@ livereload==2.5.1         # via sphinx-autobuild
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8
 mypy-extensions==0.3.0
-mypy==0.560
+mypy==0.590
 packaging==16.8           # via sphinx
 pathtools==0.1.2          # via sphinx-autobuild, watchdog
 pip-tools==1.11.0
 pluggy==0.6.0             # via pytest
 port-for==0.3.1           # via sphinx-autobuild
-psutil==5.4.3             # via mypy
 py==1.5.2                 # via pytest
 pycodestyle==2.3.1        # via flake8
 pyflakes==1.6.0           # via flake8
@@ -37,7 +36,7 @@ pygments==2.2.0           # via sphinx
 pyparsing==2.2.0          # via packaging
 pytest-env==0.6.2
 pytest-freezegun==0.2.0
-pytest-mypy==0.3.0
+pytest-mypy==0.3.1
 pytest==3.3.2
 python-dateutil==2.6.1    # via freezegun
 pytz==2017.3              # via astral, babel


### PR DESCRIPTION
It is now possible to:

*) Filter which files are considered templates, and therefore should be compiled
*) Rename template target names based on regex capture group
*) Specify either 'symlink', 'copy', or 'ignore' when handling files that are not considered to be templates

I went with the ``templates`` and ``non_templates`` config syntax.

Fixes #10.