### PR TITLE
Add module-module dependencies option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,6 +41,7 @@ Added
   indentation level in the module.
 - You can now run astrality with ``--dry-run`` in order to check which actions
   that will be executed.
+- Modules can now depend on other modules with the ``module`` requires keyword.
 
 Changed
 -------

--- a/astrality/module.py
+++ b/astrality/module.py
@@ -175,9 +175,9 @@ class Module:
 
         self.action_blocks = action_blocks
 
-        requirements = module_config.get('requires', [])
+        requirements = cast_to_list(module_config.get('requires', []))
         self.depends_on = tuple(  # type: ignore
-            requirement['module']  # type: ignore
+            requirement['module']
             for requirement
             in requirements
             if 'module' in requirement
@@ -547,6 +547,9 @@ class ModuleManager:
                 dry_run=dry_run,
             )
             self.modules[module.name] = module
+
+        # Remove modules which depends on other missing modules
+        Requirement.pop_missing_module_dependencies(self.modules)
 
         # Initialize the config directory watcher, but don't start it yet
         self.directory_watcher = DirectoryWatcher(

--- a/astrality/module.py
+++ b/astrality/module.py
@@ -89,6 +89,7 @@ class Module:
     """
 
     action_blocks: ModuleActionBlocks
+    depends_on: Tuple[str]
 
     def __init__(
         self,
@@ -173,6 +174,14 @@ class Module:
             )
 
         self.action_blocks = action_blocks
+
+        requirements = module_config.get('requires', [])
+        self.depends_on = tuple(  # type: ignore
+            requirement['module']  # type: ignore
+            for requirement
+            in requirements
+            if 'module' in requirement
+        )
 
     @staticmethod
     def prepare_on_startup_block(
@@ -380,6 +389,10 @@ class Module:
             and self.event_listener.type_ != 'static'
 
         return on_modifed or event_listener
+
+    def __repr__(self) -> str:
+        """Return string representation of Module object."""
+        return f'Module(name={self.name})'
 
     @staticmethod
     def valid_module(

--- a/astrality/module.py
+++ b/astrality/module.py
@@ -388,7 +388,18 @@ class Module:
         requires_timeout: Union[int, float],
         requires_working_directory: Path,
     ) -> bool:
-        """Check if the given dict represents a valid enabled module."""
+        """
+        Check if the given dict represents a valid enabled module.
+
+        The method determines this by inspecting any requires items the module
+        might have specified.
+
+        :param name: Name of module, used for logging purposes.
+        :param config: Configuration dictionary of the module.
+        :param requires_timeout: Time to wait for shell command requirements.
+        :param requires_working_directory: CWD for shell commands.
+        :return: True if module should be enabled.
+        """
         if not config.get('enabled', True):
             return False
 

--- a/astrality/tests/module/test_keep_running.py
+++ b/astrality/tests/module/test_keep_running.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from astrality.module import Module, ModuleManager
+from astrality.tests.utils import Retry
 
 
 def test_module_that_does_not_need_to_keep_running():
@@ -86,7 +87,9 @@ def test_that_no_reprocess_modified_files_does_not_cause_keep_running():
             },
         },
     )
-    assert module_manager.keep_running is False
+
+    # We have to retry here, as processes from earlier tests might interfer
+    assert Retry()(lambda: module_manager.keep_running is False)
 
 
 def test_that_module_manager_asks_its_modules_if_it_should_keep_running():

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -71,12 +71,3 @@ Actions module
     :undoc-members:
     :inherited-members:
     :show-inheritance:
-
-Requirements module
--------------------
-
-.. automodule:: astrality.requirements
-    :members:
-    :undoc-members:
-    :inherited-members:
-    :show-inheritance:

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -111,11 +111,18 @@ keywords:
     You can also override the default timeout on a case-by-case basis by
     setting the ``timeout`` key to a numeric value (in seconds).
 
+``module``:
+    Module dependent on other module(s), specified with the same name syntax
+    as with :ref:`enabled_modules <modules_enabled_modules>`.
+
+    If a module is missing one or more module dependencies, it will be disabled,
+    and an error will be logged.
+
 
 *All* specified dependencies must be satisfied in order to enable the module.
 
-For example, if your module depends on the ``docker`` and ``docker-machine``
-shell commands being available, the environment variable ``$ENABLE_DOCKER``
+For example, if your module depends on the ``docker`` shell command, another
+module named ``docker-machine``, the environment variable ``$ENABLE_DOCKER``
 being set, and "my_docker_container" existing, you can check this by setting
 the following requirements:
 
@@ -126,7 +133,7 @@ the following requirements:
     docker:
         requires:
             - installed: docker
-            - installed: docker-machine
+            - module: docker-machine
             - env: ENABLE_DOCKER
             - shell: '[ $(docker ps -a | grep my_docker_container) ]'
               timeout: 10 # seconds


### PR DESCRIPTION
The implementation deletes any module which does not satisfy this dependency after having parsed all the modules. This means that modules which depends on other non-existant modules will still import their context before being disabled.

Doing it this way made it much easier to implement, so I think I can stomach this small bug. You would not want to enable modules that will be disabled due to missing dependencies anyway, as it is used more as a tool to find and enable any modules which you are missing.