### PR TITLE
Add "on_setup" action block

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,7 @@ Added
 - You can now run astrality with ``--dry-run`` in order to check which actions
   that will be executed.
 - Modules can now depend on other modules with the ``module`` requires keyword.
+- Modules can now place action in a ``setup`` block, only to be executed once.
 
 Changed
 -------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -43,6 +43,8 @@ Added
   that will be executed.
 - Modules can now depend on other modules with the ``module`` requires keyword.
 - Modules can now place action in a ``setup`` block, only to be executed once.
+- You can now execute ``astrality --reset-setup module_name`` in order to
+  clear executed module setup actions.
 
 Changed
 -------

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -42,6 +42,7 @@ from mypy_extensions import TypedDict
 from astrality import compiler, utils
 from astrality.config import expand_path, GlobalModulesConfig
 from astrality.context import Context
+from astrality import executed_actions
 
 
 Replacer = Callable[[str], str]
@@ -941,4 +942,17 @@ class SetupActionBlock(ActionBlock):
         :return: List of action options of that type.
         """
         action_options = super().action_options(identifier)
-        return action_options
+        executed_setup_actions = executed_actions.ExecutedActions(
+            module_name=self.module_name,
+        )
+        not_executed = [
+            action_option
+            for action_option
+            in action_options
+            if not executed_setup_actions.executed(
+                action_type=identifier,
+                action_options=action_option,
+            )
+        ]
+        executed_setup_actions.save_checked_actions()
+        return not_executed

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -586,6 +586,9 @@ class StowAction(Action):
             as a set of target paths. If `non_templates` is 'copy', then these
             will be included as well.
         """
+        if self.null_object:
+            return {}
+
         managed_files = self.compile_action._performed_compilations.copy()
 
         if isinstance(self.non_templates_action, CopyAction):

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -942,17 +942,20 @@ class SetupActionBlock(ActionBlock):
         :return: List of action options of that type.
         """
         action_options = super().action_options(identifier)
-        executed_setup_actions = executed_actions.ExecutedActions(
-            module_name=self.module_name,
-        )
+
+        if not hasattr(self, 'executed_setup_actions'):
+            self.executed_setup_actions = executed_actions.ExecutedActions(
+                module_name=self.module_name,
+            )
+
         not_executed = [
             action_option
             for action_option
             in action_options
-            if not executed_setup_actions.executed(
+            if self.executed_setup_actions.is_new(
                 action_type=identifier,
                 action_options=action_option,
             )
         ]
-        executed_setup_actions.save_checked_actions()
+        self.executed_setup_actions.write()
         return not_executed

--- a/astrality/executed_actions.py
+++ b/astrality/executed_actions.py
@@ -2,6 +2,7 @@
 
 import os
 from pathlib import Path
+import logging
 
 from astrality import actions
 from astrality.config import expand_path
@@ -51,7 +52,7 @@ class ExecutedActions:
         action_options,
     ) -> bool:
         """
-        Return True if action config of action type has been saved earlier.
+        Return True if the specified action has not been executed earlier.
 
         :param action_type: Type of action, see ActionBlock.action_types.
         :param action_options: Configuration of action to be performed.
@@ -94,6 +95,29 @@ class ExecutedActions:
             path=self.path,
             data=file_data,
         )
+
+    def reset(self) -> None:
+        """Delete all executed module actions."""
+        file_data = utils.load_yaml(path=self.path)
+        reset_actions = file_data.pop(self.module, None)
+
+        logger = logging.getLogger(__name__)
+        if not reset_actions:
+            logger.error(
+                'No saved executed on_setup actions for module '
+                f'"{self.module}"!',
+            )
+        else:
+            logger.info(
+                f'Reset the following actions for module "{self.module}":\n' +
+                utils.yaml_str({self.module: reset_actions}),
+            )
+
+        utils.dump_yaml(
+            path=self.path,
+            data=file_data,
+        )
+        self.old_actions = {}
 
     @property
     def path(self) -> Path:

--- a/astrality/executed_actions.py
+++ b/astrality/executed_actions.py
@@ -21,7 +21,7 @@ def xdg_data_home(application: str) -> Path:
         config_directory=Path('/'),
     )
     application_data_home = xdg_data_home / application
-    application_data_home.mkdir(exist_ok=True)
+    application_data_home.mkdir(parents=True, exist_ok=True)
     return application_data_home
 
 

--- a/astrality/executed_actions.py
+++ b/astrality/executed_actions.py
@@ -16,9 +16,6 @@ class ExecutedActions:
     :param module_name: Unique string id of module.
     """
 
-    # True if we have checked executed() on a new action configuration.
-    newly_executed_actions: bool
-
     # Path to file containing executed setup actions
     _path: Path
 

--- a/astrality/executed_actions.py
+++ b/astrality/executed_actions.py
@@ -1,0 +1,103 @@
+"""Module which keeps track of module setup block actions."""
+
+import os
+from pathlib import Path
+
+from astrality import actions
+from astrality.config import expand_path
+from astrality import utils
+
+
+def xdg_data_home(application: str) -> Path:
+    """Return XDG directory standard path for application data."""
+    xdg_data_home = expand_path(
+        path=Path(
+            os.environ.get(
+                'XDG_DATA_HOME',
+                '$HOME/.local/share',
+            ),
+        ),
+        config_directory=Path('/'),
+    )
+    application_data_home = xdg_data_home / application
+    application_data_home.mkdir(exist_ok=True)
+    return application_data_home
+
+
+class ExecutedActions:
+    """
+    Object which persists executed module actions.
+
+    :param module_name: Unique string id of module.
+    """
+
+    # True if we have checked executed() on a new action configuration.
+    newly_executed_actions: bool
+
+    def __init__(self, module_name: str) -> None:
+        """Construct ExecutedActions object."""
+        self.module = module_name
+        self.file_data = utils.load_yaml(path=self.path)
+        self.executed_actions = self.file_data.setdefault(
+            self.module,
+            {},
+        )
+        self.newly_executed_actions = False
+
+    def executed(
+        self,
+        action_type: str,
+        action_options,
+    ) -> bool:
+        """
+        Return True if action config of action type has been saved earlier.
+
+        :param action_type: Type of action, see ActionBlock.action_types.
+        :param action_options: Configuration of action to be performed.
+        """
+        assert action_type in actions.ActionBlock.action_types
+        if not action_options:
+            # Empty actions can be disregarded.
+            return False
+
+        has_been_executed = action_options in self.executed_actions.get(
+            action_type,
+            [],
+        )
+
+        if not has_been_executed:
+            self.executed_actions            \
+                .setdefault(action_type, []) \
+                .append(action_options)
+            self.newly_executed_actions = True
+
+        return has_been_executed
+
+    def save_checked_actions(self) -> None:
+        """Persist all actions that have been checked in object lifetime."""
+        if not self.newly_executed_actions:
+            return
+
+        file_data = utils.load_yaml(path=self.path)
+        file_data[self.module] = self.executed_actions
+        utils.dump_yaml(
+            path=self.path,
+            data=file_data,
+        )
+
+    @property
+    def path(self) -> Path:
+        """Return path to file which stores executed module setup actions."""
+        if hasattr(self, '_path'):
+            return self._path
+
+        self._path: Path = xdg_data_home('astrality') / 'setup.yml'
+        if not self._path.exists():
+            self._path.touch()
+            utils.dump_yaml(data={}, path=self._path)
+
+        return self._path
+
+    def __repr__(self) -> str:
+        """Return string representation of ExecutedActions object."""
+        return f'ExecutedActions(module_name={self.module}, path={self.path})'

--- a/astrality/module.py
+++ b/astrality/module.py
@@ -46,7 +46,7 @@ class ModuleConfigDict(TypedDict, total=False):
     requires: Union[RequirementDict, List[RequirementDict]]
     event_listener: EventListenerConfig
 
-    setup: ActionBlockDict
+    on_setup: ActionBlockDict
     on_startup: ActionBlockDict
     on_exit: ActionBlockDict
     on_event: ActionBlockDict
@@ -56,7 +56,7 @@ class ModuleConfigDict(TypedDict, total=False):
 class ModuleActionBlocks(TypedDict):
     """Contents of Module().action_blocks."""
 
-    setup: SetupActionBlock
+    on_setup: SetupActionBlock
     on_startup: ActionBlock
     on_event: ActionBlock
     on_exit: ActionBlock
@@ -154,8 +154,8 @@ class Module:
 
         # Create special case setup action block, it removes any action already
         # performed.
-        action_blocks['setup'] = SetupActionBlock(  # type: ignore
-            action_block=module_config.get('setup', {}),
+        action_blocks['on_setup'] = SetupActionBlock(  # type: ignore
+            action_block=module_config.get('on_setup', {}),
             module_name=self.name,
             **params,
         )
@@ -250,7 +250,7 @@ class Module:
             assert name == 'on_modified'
             return self.action_blocks[name][path]  # type: ignore
         else:
-            assert name in ('setup', 'on_startup', 'on_event', 'on_exit',)
+            assert name in ('on_setup', 'on_startup', 'on_event', 'on_exit',)
             return self.action_blocks[name]  # type: ignore
 
     def execute(
@@ -316,7 +316,7 @@ class Module:
     def all_action_blocks(self) -> Iterable[ActionBlock]:
         """Return flatten tuple of all module action blocks."""
         return (
-            self.action_blocks['setup'],
+            self.action_blocks['on_setup'],
             self.action_blocks['on_startup'],
             self.action_blocks['on_event'],
             self.action_blocks['on_exit'],
@@ -653,7 +653,7 @@ class ModuleManager:
         :module: Specific module to be executed. If not provided, then all
             managed modules will be executed.
         """
-        assert block in ('setup', 'on_startup', 'on_event', 'on_exit',)
+        assert block in ('on_setup', 'on_startup', 'on_event', 'on_exit',)
 
         modules: Iterable[Module]
         if isinstance(module, Module):
@@ -681,7 +681,7 @@ class ModuleManager:
         """
         Run setup actions specified by the managed modules, not yet executed.
         """
-        self.execute(action='all', block='setup')
+        self.execute(action='all', block='on_setup')
 
     def startup(self):
         """

--- a/astrality/module.py
+++ b/astrality/module.py
@@ -56,7 +56,7 @@ class ModuleConfigDict(TypedDict, total=False):
 class ModuleActionBlocks(TypedDict):
     """Contents of Module().action_blocks."""
 
-    setup: ActionBlock
+    setup: SetupActionBlock
     on_startup: ActionBlock
     on_event: ActionBlock
     on_exit: ActionBlock
@@ -595,6 +595,9 @@ class ModuleManager:
             # is only run when the event *changes*
             self.last_module_events = self.module_events()
 
+            # Perform setup actions not yet executed
+            self.setup()
+
             # Perform all startup actions
             self.startup()
         elif self.last_module_events != self.module_events():
@@ -650,7 +653,7 @@ class ModuleManager:
         :module: Specific module to be executed. If not provided, then all
             managed modules will be executed.
         """
-        assert block in ('on_startup', 'on_event', 'on_exit',)
+        assert block in ('setup', 'on_startup', 'on_event', 'on_exit',)
 
         modules: Iterable[Module]
         if isinstance(module, Module):
@@ -673,6 +676,12 @@ class ModuleManager:
                     block=block,
                     dry_run=self.dry_run,
                 )
+
+    def setup(self) -> None:
+        """
+        Run setup actions specified by the managed modules, not yet executed.
+        """
+        self.execute(action='all', block='setup')
 
     def startup(self):
         """

--- a/astrality/tests/conftest.py
+++ b/astrality/tests/conftest.py
@@ -190,18 +190,23 @@ def action_block_factory(test_config_directory):
 
 
 @pytest.yield_fixture(autouse=True)
-def patch_data_dir(tmpdir, monkeypatch):
-    """Set DATA_HOME directory to a test directory in all tests."""
+def patch_xdg_directory_standard(tmpdir, monkeypatch, request):
+    """During testing, the XDG directory standard is monkeypatched."""
+    if 'dont_patch_xdg' in request.keywords:
+        yield
+        return
+
     data_dir = Path(tmpdir).parent / '.local' / 'share' / 'astrality'
-    data_dir.mkdir(parents=True)
+    data_dir.mkdir(parents=True, exist_ok=True)
 
     monkeypatch.setattr(
-        astrality.executed_actions,
-        'xdg_data_home',
-        lambda x: data_dir,
+        astrality.xdg.XDG,
+        'data_home',
+        data_dir,
     )
 
     yield data_dir
 
     # Delete directory for next test
-    shutil.rmtree(str(data_dir))
+    if data_dir.exists():
+        shutil.rmtree(str(data_dir))

--- a/astrality/tests/conftest.py
+++ b/astrality/tests/conftest.py
@@ -1,9 +1,11 @@
 """Application wide fixtures."""
 import os
 from pathlib import Path
+import shutil
 
 import pytest
 
+import astrality
 from astrality.actions import ActionBlock
 from astrality.config import user_configuration
 from astrality.context import Context
@@ -185,3 +187,21 @@ def action_block_factory(test_config_directory):
         )
 
     return _action_block_factory
+
+
+@pytest.yield_fixture(autouse=True)
+def patch_data_dir(tmpdir, monkeypatch):
+    """Set DATA_HOME directory to a test directory in all tests."""
+    data_dir = Path(tmpdir).parent / '.local' / 'share' / 'astrality'
+    data_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(
+        astrality.executed_actions,
+        'xdg_data_home',
+        lambda x: data_dir,
+    )
+
+    yield data_dir
+
+    # Delete directory for next test
+    shutil.rmtree(str(data_dir))

--- a/astrality/tests/module/test_keep_running.py
+++ b/astrality/tests/module/test_keep_running.py
@@ -84,8 +84,10 @@ def test_that_no_reprocess_modified_files_does_not_cause_keep_running():
         config={
             'modules': {
                 'reprocess_modified_files': False,
+                'enabled_modules': [{'name': 'A'}],
             },
         },
+        modules={'A': {}},
     )
 
     # We have to retry here, as processes from earlier tests might interfer

--- a/astrality/tests/module/test_setup_action_block.py
+++ b/astrality/tests/module/test_setup_action_block.py
@@ -10,7 +10,7 @@ def test_that_setup_block_is_only_executed_once(tmpdir):
     touched = Path(tmpdir, 'touched.tmp')
     modules = {
         'A': {
-            'setup': {
+            'on_setup': {
                 'run': {
                     'shell': f'touch {touched}',
                 },

--- a/astrality/tests/module/test_setup_action_block.py
+++ b/astrality/tests/module/test_setup_action_block.py
@@ -1,0 +1,36 @@
+"""Tests for handling setup action blocks in ModuleManager."""
+
+from pathlib import Path
+
+from astrality.module import ModuleManager
+
+
+def test_that_setup_block_is_only_executed_once(tmpdir):
+    """Setup blocks in modules should only be performed once."""
+    touched = Path(tmpdir, 'touched.tmp')
+    modules = {
+        'A': {
+            'setup': {
+                'run': {
+                    'shell': f'touch {touched}',
+                },
+            },
+        },
+    }
+    module_manager = ModuleManager(modules=modules)
+
+    # The touched file should not exist before we have done anything
+    assert not touched.exists()
+
+    # After finishing tasks, the file should be touched
+    module_manager.finish_tasks()
+    assert touched.exists()
+
+    # We now create a new object lifetime
+    del module_manager
+    touched.unlink()
+
+    # The setup block should now *not* be executed
+    module_manager = ModuleManager(modules=modules)
+    module_manager.finish_tasks()
+    assert not touched.exists()

--- a/astrality/tests/module/test_setup_block.py
+++ b/astrality/tests/module/test_setup_block.py
@@ -1,0 +1,33 @@
+"""Tests for setup block in module."""
+
+from pathlib import Path
+
+from astrality.actions import SetupActionBlock
+from astrality.module import Module
+
+
+def test_that_module_block_is_persisted(patch_data_dir):
+    """Module should create a 'setup' action block."""
+    module_config = {
+        'setup': {
+            'run': {
+                'shell': 'echo first time!',
+            },
+        },
+    }
+    params = {
+        'name': 'test',
+        'module_config': module_config,
+        'module_directory': Path(__file__).parent,
+    }
+
+    module = Module(**params)
+    assert isinstance(module.get_action_block(name='setup'), SetupActionBlock)
+    assert module.execute(action='run', block='setup') == (
+        ('echo first time!', 'first time!',),
+    )
+
+    # After creating this module again, the run action should not be performed.
+    del module
+    module = Module(**params)
+    assert module.execute(action='run', block='setup') == tuple()

--- a/astrality/tests/module/test_setup_block.py
+++ b/astrality/tests/module/test_setup_block.py
@@ -6,7 +6,7 @@ from astrality.actions import SetupActionBlock
 from astrality.module import Module
 
 
-def test_that_module_block_is_persisted(patch_data_dir):
+def test_that_module_block_is_persisted():
     """Module should create a 'setup' action block."""
     module_config = {
         'on_setup': {

--- a/astrality/tests/module/test_setup_block.py
+++ b/astrality/tests/module/test_setup_block.py
@@ -9,7 +9,7 @@ from astrality.module import Module
 def test_that_module_block_is_persisted(patch_data_dir):
     """Module should create a 'setup' action block."""
     module_config = {
-        'setup': {
+        'on_setup': {
             'run': {
                 'shell': 'echo first time!',
             },
@@ -22,12 +22,15 @@ def test_that_module_block_is_persisted(patch_data_dir):
     }
 
     module = Module(**params)
-    assert isinstance(module.get_action_block(name='setup'), SetupActionBlock)
-    assert module.execute(action='run', block='setup') == (
+    assert isinstance(
+        module.get_action_block(name='on_setup'),
+        SetupActionBlock,
+    )
+    assert module.execute(action='run', block='on_setup') == (
         ('echo first time!', 'first time!',),
     )
 
     # After creating this module again, the run action should not be performed.
     del module
     module = Module(**params)
-    assert module.execute(action='run', block='setup') == tuple()
+    assert module.execute(action='run', block='on_setup') == tuple()

--- a/astrality/tests/test_astrality.py
+++ b/astrality/tests/test_astrality.py
@@ -39,11 +39,6 @@ def test_interrupt_of_main_process():
     assert astrality_process.returncode == 0
 
 
-@pytest.mark.slow
-def test_invocation_of_main_process():
-    main(test=True)
-
-
 def test_enabling_specific_module_from_command_line(
     caplog,
     monkeypatch,

--- a/astrality/tests/test_executed_actions.py
+++ b/astrality/tests/test_executed_actions.py
@@ -1,0 +1,40 @@
+"""Tests for astrality.executed_actions.ExecutedActions."""
+
+from astrality.executed_actions import ExecutedActions
+
+
+def test_that_executed_action_path_is_monkeypatched_in_all_files():
+    """Autouse fixture should monkeypatch path property of ExecutedActions."""
+    executed_actions = ExecutedActions(module_name='github::user/repo::module')
+    path = executed_actions.path
+    assert path.is_file()
+    assert path.name == 'setup.yml'
+    assert path.parent.name == 'astrality'
+    assert 'test' in path.parents[3].name
+
+
+def test_that_actions_are_saved_to_file():
+    """Saved actions should be persisted properly."""
+    action_option = {'shell': 'echo setup'}
+    executed_actions = ExecutedActions(module_name='github::user/repo::module')
+
+    # This action has not been executed yet.
+    assert not executed_actions.executed(
+        action_type='run',
+        action_options=action_option,
+    )
+
+    # We save checked actions, and now it should count as executed.
+    executed_actions.save_checked_actions()
+    assert executed_actions.executed(
+        action_type='run',
+        action_options=action_option,
+    )
+
+    # The action should still be counted as executed between object lifetimes.
+    del executed_actions
+    executed_actions = ExecutedActions(module_name='github::user/repo::module')
+    assert executed_actions.executed(
+        action_type='run',
+        action_options=action_option,
+    )

--- a/astrality/tests/test_executed_actions.py
+++ b/astrality/tests/test_executed_actions.py
@@ -1,10 +1,8 @@
 """Tests for astrality.executed_actions.ExecutedActions."""
 
-import os
-from pathlib import Path
 import logging
 
-from astrality.executed_actions import ExecutedActions, xdg_data_home
+from astrality.executed_actions import ExecutedActions
 
 
 def test_that_executed_action_path_is_monkeypatched_in_all_files():
@@ -15,26 +13,6 @@ def test_that_executed_action_path_is_monkeypatched_in_all_files():
     assert path.name == 'setup.yml'
     assert path.parent.name == 'astrality'
     assert 'test' in path.parents[3].name
-
-
-def test_xdg_data_home_default_location():
-    """Default location for XDG_DATA_HOME should be respected."""
-    default_dir = xdg_data_home('astrality')
-    assert default_dir == Path('~/.local/share/astrality').expanduser()
-    assert default_dir.is_dir()
-
-
-def test_xdg_data_home_using_environment_variable(monkeypatch, tmpdir):
-    """XDG_DATA_HOME environment variables should be respected."""
-    custom_data_home = Path(tmpdir, 'data')
-    monkeypatch.setattr(
-        os,
-        'environ',
-        {'XDG_DATA_HOME': str(custom_data_home)},
-    )
-    data_home = xdg_data_home('astrality')
-    assert data_home == custom_data_home / 'astrality'
-    assert data_home.is_dir()
 
 
 def test_that_actions_are_saved_to_file(caplog):

--- a/astrality/tests/test_executed_actions.py
+++ b/astrality/tests/test_executed_actions.py
@@ -1,8 +1,10 @@
 """Tests for astrality.executed_actions.ExecutedActions."""
 
+import os
+from pathlib import Path
 import logging
 
-from astrality.executed_actions import ExecutedActions
+from astrality.executed_actions import ExecutedActions, xdg_data_home
 
 
 def test_that_executed_action_path_is_monkeypatched_in_all_files():
@@ -13,6 +15,26 @@ def test_that_executed_action_path_is_monkeypatched_in_all_files():
     assert path.name == 'setup.yml'
     assert path.parent.name == 'astrality'
     assert 'test' in path.parents[3].name
+
+
+def test_xdg_data_home_default_location():
+    """Default location for XDG_DATA_HOME should be respected."""
+    default_dir = xdg_data_home('astrality')
+    assert default_dir == Path('~/.local/share/astrality').expanduser()
+    assert default_dir.is_dir()
+
+
+def test_xdg_data_home_using_environment_variable(monkeypatch, tmpdir):
+    """XDG_DATA_HOME environment variables should be respected."""
+    custom_data_home = Path(tmpdir, 'data')
+    monkeypatch.setattr(
+        os,
+        'environ',
+        {'XDG_DATA_HOME': str(custom_data_home)},
+    )
+    data_home = xdg_data_home('astrality')
+    assert data_home == custom_data_home / 'astrality'
+    assert data_home.is_dir()
 
 
 def test_that_actions_are_saved_to_file(caplog):

--- a/astrality/tests/test_executed_actions.py
+++ b/astrality/tests/test_executed_actions.py
@@ -19,14 +19,14 @@ def test_that_actions_are_saved_to_file():
     executed_actions = ExecutedActions(module_name='github::user/repo::module')
 
     # This action has not been executed yet.
-    assert not executed_actions.executed(
+    assert executed_actions.is_new(
         action_type='run',
         action_options=action_option,
     )
 
     # We save checked actions, and now it should count as executed.
-    executed_actions.save_checked_actions()
-    assert executed_actions.executed(
+    executed_actions.write()
+    assert not executed_actions.is_new(
         action_type='run',
         action_options=action_option,
     )
@@ -34,7 +34,7 @@ def test_that_actions_are_saved_to_file():
     # The action should still be counted as executed between object lifetimes.
     del executed_actions
     executed_actions = ExecutedActions(module_name='github::user/repo::module')
-    assert executed_actions.executed(
+    assert not executed_actions.is_new(
         action_type='run',
         action_options=action_option,
     )

--- a/astrality/tests/test_executed_actions.py
+++ b/astrality/tests/test_executed_actions.py
@@ -1,5 +1,7 @@
 """Tests for astrality.executed_actions.ExecutedActions."""
 
+import logging
+
 from astrality.executed_actions import ExecutedActions
 
 
@@ -13,7 +15,7 @@ def test_that_executed_action_path_is_monkeypatched_in_all_files():
     assert 'test' in path.parents[3].name
 
 
-def test_that_actions_are_saved_to_file():
+def test_that_actions_are_saved_to_file(caplog):
     """Saved actions should be persisted properly."""
     action_option = {'shell': 'echo setup'}
     executed_actions = ExecutedActions(module_name='github::user/repo::module')
@@ -38,3 +40,31 @@ def test_that_actions_are_saved_to_file():
         action_type='run',
         action_options=action_option,
     )
+
+    # But when we reset the module, it should be counted as new
+    del executed_actions
+    executed_actions = ExecutedActions(module_name='github::user/repo::module')
+
+    caplog.clear()
+    executed_actions.reset()
+    assert executed_actions.is_new(
+        action_type='run',
+        action_options=action_option,
+    )
+
+    # Check that info is logged on success
+    assert caplog.record_tuples[0][1] == logging.INFO
+
+    # It should also be reset after loading from disk again
+    executed_actions.reset()
+    del executed_actions
+    executed_actions = ExecutedActions(module_name='github::user/repo::module')
+    assert executed_actions.is_new(
+        action_type='run',
+        action_options=action_option,
+    )
+
+    # Check that error is logged on invalid module name
+    caplog.clear()
+    ExecutedActions(module_name='i_do_not_exist').reset()
+    assert caplog.record_tuples[0][1] == logging.ERROR

--- a/astrality/tests/test_filewatcher.py
+++ b/astrality/tests/test_filewatcher.py
@@ -107,7 +107,7 @@ def test_filesystem_watcher(watch_dir):
 
     # Subdirectories are not of interest
     assert retry(lambda: event_saver.argument == test_file1)
-    assert retry(lambda: event_saver.called == 1)
+    assert retry(lambda: event_saver.called >= 1)
 
     # Create a file in the subdirectory
     test_file2.write_text('test')

--- a/astrality/tests/test_xdg.py
+++ b/astrality/tests/test_xdg.py
@@ -1,0 +1,46 @@
+"""Tests for astrality.xdg module."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from astrality.xdg import XDG
+
+
+@pytest.mark.dont_patch_xdg
+def test_xdg_data_home_default_location(monkeypatch):
+    """Default location for XDG_DATA_HOME should be respected."""
+    xdg = XDG()
+    default_dir = xdg.data_home
+    assert default_dir == Path('~/.local/share/astrality').expanduser()
+    assert default_dir.is_dir()
+
+
+@pytest.mark.dont_patch_xdg
+def test_xdg_data_home_using_environment_variable(monkeypatch, tmpdir):
+    """XDG_DATA_HOME environment variables should be respected."""
+    custom_data_home = Path(tmpdir, 'data')
+    monkeypatch.setattr(
+        os,
+        'environ',
+        {'XDG_DATA_HOME': str(custom_data_home)},
+    )
+
+    xdg = XDG()
+    data_home = xdg.data_home
+    assert data_home == custom_data_home / 'astrality'
+    assert data_home.is_dir()
+
+
+def test_retrieving_data_resource(patch_xdg_directory_standard):
+    """The data method should retrieve file resource from data home."""
+    xdg = XDG()
+    resource = xdg.data('modules/test.tmp')
+    assert resource == patch_xdg_directory_standard / 'modules' / 'test.tmp'
+    assert resource.exists()
+
+    # We should get the same file again
+    resource.write_text('hello')
+    refetched_resource = xdg.data('modules/test.tmp')
+    assert refetched_resource.read_text() == 'hello'

--- a/astrality/utils.py
+++ b/astrality/utils.py
@@ -198,6 +198,16 @@ def dump_yaml(path: Path, data: Dict) -> None:
     :param path: Path to file to be created.
     :param data: Data to be dumped to file.
     """
-    str_data = dump(data, Dumper=Dumper)
+    str_data = yaml_str(data)
     with open(path, 'w') as yaml_file:
         yaml_file.write(str_data)
+
+
+def yaml_str(data: Any) -> str:
+    """
+    Return YAML string representation of data.
+
+    :param data: Data to be converted to YAML string format.
+    :return: YAML string representation of python data structure.
+    """
+    return dump(data, Dumper=Dumper)

--- a/astrality/utils.py
+++ b/astrality/utils.py
@@ -12,12 +12,13 @@ from astrality.context import Context
 
 logger = logging.getLogger(__name__)
 
-from yaml import load  # noqa
+# Try to import PyYAML library for faster YAML parsing
+from yaml import dump, load  # noqa
 try:
-    from yaml import CLoader as Loader  # type: ignore
+    from yaml import CLoader as Loader, CDumper as Dumper  # type: ignore
     logger.info('Using LibYAML bindings for faster .yml parsing.')
 except ImportError:  # pragma: no cover
-    from yaml import Loader
+    from yaml import Loader, Dumper
     logger.warning(
         'LibYAML not installed.'
         'Using somewhat slower pure python implementation.',
@@ -177,3 +178,26 @@ def compile_yaml(
     )
 
     return load(StringIO(config_string), Loader=Loader)
+
+
+def load_yaml(path: Path) -> Any:
+    """
+    Load content from YAML file.
+
+    :param path: Path to YAML formatted file.
+    :return: Contents of YAML file.
+    """
+    with open(path, 'r') as yaml_file:
+        return load(yaml_file.read(), Loader=Loader)
+
+
+def dump_yaml(path: Path, data: Dict) -> None:
+    """
+    Dump data to yaml file.
+
+    :param path: Path to file to be created.
+    :param data: Data to be dumped to file.
+    """
+    str_data = dump(data, Dumper=Dumper)
+    with open(path, 'w') as yaml_file:
+        yaml_file.write(str_data)

--- a/astrality/xdg.py
+++ b/astrality/xdg.py
@@ -1,0 +1,47 @@
+"""Module implementing XDG directory standard for astrality."""
+
+import os
+from pathlib import Path
+
+
+class XDG:
+    """
+    Class for handling the XDG directory standard.
+
+    :param application_name: Name of application to use XDG directory standard.
+    """
+
+    def __init__(self, application_name: str = 'astrality') -> None:
+        """Contstruct XDG object for application."""
+        self.application_name = application_name
+        self.XDG_DATA_HOME = Path(os.environ.get(
+            'XDG_DATA_HOME',
+            '~/.local/share',
+        )).expanduser()
+        self.XDG_CONFIG_HOME = Path(os.environ.get(
+            'XDG_CONFIG_HOME',
+            '~/.config',
+        )).expanduser()
+
+    @property
+    def data_home(self) -> Path:
+        """
+        Return XDG_DATA_HOME directory of application.
+
+        :return: Path to resolved value of XDG_DATA_HOME.
+        """
+        application_data_home = self.XDG_DATA_HOME / self.application_name
+        application_data_home.mkdir(parents=True, exist_ok=True)
+        return application_data_home
+
+    def data(self, resource: str) -> Path:
+        """
+        Return file resource of application.
+
+        :param resource: Relative string path, i.e. $XDG_DATA_HOME/<resource>.
+        :return: Path to touched data resource.
+        """
+        resource_path = self.data_home / resource
+        resource_path.parent.mkdir(parents=True, exist_ok=True)
+        resource_path.touch(exist_ok=True)
+        return resource_path

--- a/bin/astrality
+++ b/bin/astrality
@@ -11,6 +11,7 @@ sys.path.append(str(PROJECT_DIR))
 
 from astrality.astrality import main
 from astrality.config import resolve_config_directory, create_config_directory
+from astrality.executed_actions import ExecutedActions
 
 coloredlogs.install(fmt='%(asctime)s %(name)8s %(levelname)s\n%(message)s\n')
 config_dir = resolve_config_directory()
@@ -46,6 +47,12 @@ parser.add_argument(
     action='append',
 )
 parser.add_argument(
+    '--reset-setup',
+    help='Reset all setup actions of module.',
+    action='append',
+    default=[],
+)
+parser.add_argument(
     '-l',
     '--logging-level',
     help='Set the degree of logging of the application. Default: INFO.',
@@ -55,6 +62,11 @@ parser.add_argument(
     nargs='?',
 )
 args = parser.parse_args()
+
+if args.reset_setup:
+    for module_name in args.reset_setup:
+        ExecutedActions(module_name=module_name).reset()
+    sys.exit(0)
 
 if args.create_example_config:
     create_config_directory(empty=False)

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -159,13 +159,22 @@ have to define *when* to perform them. This is done by defining those
 
     .. _module_events_on_startup:
 
+    ``setup``:
+        Tasks to be performed only once and never again. Can be used for
+        setting up dependencies.
+
+        Executed actions are written to
+        ``$XDG_DATA_HOME/astrality/setup.yml``, by default
+        ``$HOME/.local/share``. Modify this file if you want to re-execute
+        setup actions.
+
     ``on_startup``:
         Tasks to be performed when Astrality first starts up.
         Useful for compiling templates that don't need to change after they
         have been compiled.
 
-        Actions defined outside action blocks are considered to be part of this
-        block.
+        *Actions defined outside action blocks are considered to be part of this
+        block.*
 
     .. _module_events_on_exit:
 
@@ -204,6 +213,9 @@ Demonstration of module action blocks:
     module_name:
         ...startup actions (option 1)...
 
+        setup:
+            ...setup actions...
+
         on_startup:
             ...startup actions (option 2)...
 
@@ -214,8 +226,8 @@ Demonstration of module action blocks:
             ...shutdow actions...
 
         on_modified:
-            some/template/path:
-                ...some/template/path modified actions...
+            some/file/path:
+                ...some/file/path modified actions...
 
 .. note::
     On Astrality startup, the ``on_startup`` event will be triggered, but

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -155,18 +155,19 @@ Action blocks
 
 When you want to assign :ref:`tasks <actions>` for Astrality to perform, you
 have to define *when* to perform them. This is done by defining those
-``actions`` in one of four available ``action blocks``.
+``actions`` in one of five available ``action blocks``.
 
     .. _module_events_on_startup:
 
-    ``setup``:
+    ``on_setup``:
         Tasks to be performed only once and never again. Can be used for
         setting up dependencies.
 
         Executed actions are written to
         ``$XDG_DATA_HOME/astrality/setup.yml``, by default
-        ``$HOME/.local/share``. Modify this file if you want to re-execute
-        setup actions.
+        ``$HOME/.local/share``. Execute ``astrality --reset-setup module_name``
+        if you want to re-execute a module's setup actions during the next
+        run.
 
     ``on_startup``:
         Tasks to be performed when Astrality first starts up.
@@ -213,7 +214,7 @@ Demonstration of module action blocks:
     module_name:
         ...startup actions (option 1)...
 
-        setup:
+        on_setup:
             ...setup actions...
 
         on_startup:


### PR DESCRIPTION
This new action block allows you to specify actions that only needs to be executed once, such as installing dependencies, and so on.

At the moment, all setup actions are assumed to be executed at startup, and are therefore written to disk. If something fails during setup, Astrality will not run those actions again next time. The implementation allows to only save executed actions once they have been *executed*, but using that capability would require some more work/refactoring. I will postpone it for another time.

For now, it works in happy path, and you can always run ``astrality --reset-setup module_name`` if something did not pan out.