### PR TITLE
When comparing symlinks to symlinks, the content should also be resolved.

### DIFF
--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -388,7 +388,7 @@ class SymlinkAction(Action):
             self.symlinked_files[content].add(symlink)
             log_msg = f'[symlink] Content "{content}" -> Target: "{symlink}".'
 
-            if symlink.resolve() == content:
+            if symlink.resolve() == content.resolve():
                 continue
 
             if dry_run:


### PR DESCRIPTION
I had this case: a module (vim) containing two files (init.vim and vimrc), vimrc being a symlink -> init.vim.
Uppon stow, \~/.vim/vimrc points to the correct file (modules/vim/.../vimrc).
Uppon restow, the symlink action wouldn't recognize the link was already there because only the target part was being resolved (~/.vim/vimrc -> modules/vim/.../vimrc -> modules/vim/.../init.vim) and compared against the content (modueles/vim/.../vimrc). This produced an error on line 402 uppon re-symlinking.

I'm not sure this is the best solution and that it doesn't introduces new bugs.