### PR TITLE
Delete created directories on module cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,15 @@ The format is based on `Keep a Changelog
 <http://keepachangelog.com/en/1.0.0/>`_ and this project adheres to `Semantic
 Versioning <http://semver.org/spec/v2.0.0.html>`_.
 
+[UNRELEASED]
+============
+
+Fixed
+-----
+
+- Astrality now cleans up directories created by `symlink` and `copy` actions
+  when modules are cleaned up with the `--cleanup` flag.
+
 [1.1.0] - 2018-06-24
 ====================
 

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -465,8 +465,7 @@ class CopyAction(Action):
                 continue
 
             logger.info(log_msg)
-            copy.parent.mkdir(parents=True, exist_ok=True)
-
+            self.creation_store.mkdir(copy.parent)
             self.creation_store.backup(path=copy)
             utils.copy(
                 source=content,

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -396,8 +396,7 @@ class SymlinkAction(Action):
                 continue
 
             logger.info(log_msg)
-            symlink.parent.mkdir(parents=True, exist_ok=True)
-
+            self.creation_store.mkdir(symlink.parent)
             self.creation_store.backup(path=symlink)
             symlink.symlink_to(content)
             self.creation_store.insert_creation(


### PR DESCRIPTION
This PR deletes directories created by the `symlink` and `copy` actions.

The following decisions have been made, but I'm open for input:
* We only delete created directories if they are empty after having deleted all other created files and symlinks.
* Created directories that couldn't be deleted, are still tracked by astrality, offering the ability to "retry" the cleanup action.
* Users are instructed to manually delete files not created by astrality, before we are willing to delete such directories.
* There is no way to override this safe behavior at the moment.
* Warnings are printed to the terminal when this occurs.

Fixes #139 

TODO:
- [x] Support persistence of created directories in the `persistence` module.
- [x] Don't delete directories that contain new files not created by the module.
- [x] Actually persist created directories when they are created, using the capabilities introduced above.
- [x] Support nested directory creations and deletions. Deletions are relatively simple, as we can traverse the created directories bottom-up, but now we need some way to find out exactly which directories are created on `Pathlib.path.mkdir(parents=True)`.

Work for future PRs:
- [ ] Hash created directories.
- [ ] Use this capability for other actions, such as `compile` and `stow`.