### PR TITLE
Clean up directories created by compile-type actions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,8 +14,8 @@ Versioning <http://semver.org/spec/v2.0.0.html>`_.
 Fixed
 -----
 
-- Astrality now cleans up directories created by `symlink` and `copy` actions
-  when modules are cleaned up with the `--cleanup` flag.
+- Astrality now cleans up directories created by the `compile`, `stow`,
+  `symlink` and `copy` actions when modules are cleaned up with the `--cleanup` flag.
 
 [1.1.0] - 2018-06-24
 ====================

--- a/astrality/actions.py
+++ b/astrality/actions.py
@@ -273,6 +273,7 @@ class CompileAction(Action):
                 )
             else:
                 self.creation_store.backup(path=target_file)
+                self.creation_store.mkdir(path=target_file.parent)
                 compiler.compile_template(
                     template=content_file,
                     target=target_file,


### PR DESCRIPTION
Now all the actions which can be reasonably cleaned up, are properly cleaned up.